### PR TITLE
fix: stop exposing stored secrets and harden credential transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,3 +266,15 @@ Tests use `cy.apollo(...)` for GraphQL calls. GraphQL fixture files are in `test
 6. **Base URL trailing slash** — always strip before appending path segments to avoid double slashes.
 7. **`rateLimit.requestsPerSecond` requires restart** — `RateLimitInterceptor` is instantiated once during `init()` with the config value at that moment. Updating the OSGi config at runtime does not rebuild the interceptor; a module restart is required for the new rate to take effect.
 8. **Never follow `next_page_url` in the purge loop** — CustomGPT pagination is offset-based. Always re-query the first-page URL after each deletion round; see the "Purge: streaming-batch pattern" section above.
+
+---
+
+## Security invariants (do not regress)
+
+These were hardened in SECURITY-746. `SecurityUtils` (pure, unit-tested) is the single source of truth.
+
+1. **Secrets are write-only.** `token`, `jahiaPassword` and `jahiaServerCookieValue` must **never** be returned to the client. `AdminQueries.getSettings` returns `SecurityUtils.maskSecretForDisplay(...)` (the `********` placeholder when set, `""` when not). `saveSettings` persists a secret only via `putSecretIfChanged`, which skips a blank value or the placeholder echoed back unchanged — so the existing stored secret is preserved. Do **not** switch these back to `putIfNotNull` or surface the raw getter in the GraphQL schema.
+2. **`apiBaseUrl` must be https.** It travels with the Bearer token on every API call. `saveSettings` rejects any non-`https://` value via `SecurityUtils.isHttpsUrl`. Validate with `java.net.URI` (never `URL`) so the check itself cannot trigger DNS/SSRF.
+3. **Basic auth only over HTTPS.** `CustomGptIndexerNodeHandler.getJahiaPageContent` attaches the Jahia password only when the rendering URL (derived from the site's `sitemapIndexURL` property, which may be `http://`) is HTTPS; otherwise it logs and skips.
+4. **`customGptClient` does not follow redirects** (`followRedirects(false)` / `followSslRedirects(false)`) so the Authorization header is never forwarded to a redirect target. The `jahiaClient` may still redirect (page rendering), which is why its Basic auth is HTTPS-gated per point 3.
+5. **Secrets at rest** live in the OSGi `.cfg` in cleartext (inherent to ConfigurationAdmin) — keep `digital-factory-data/karaf/etc/*.cfg` filesystem-protected; this is a deployment, not a code, control.

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,18 @@
             <artifactId>org.apache.felix.utils</artifactId>
             <version>1.11.8</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.25.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/models/GqlCustomGptAdminMutationResult.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/models/GqlCustomGptAdminMutationResult.java
@@ -9,6 +9,7 @@ import org.jahia.community.modules.customgpt.CustomGptConstants;
 import org.jahia.community.modules.customgpt.indexer.NodeReindexAsyncJob;
 import org.jahia.community.modules.customgpt.service.Service;
 import org.jahia.community.modules.customgpt.service.models.Site;
+import org.jahia.community.modules.customgpt.util.SecurityUtils;
 import org.jahia.modules.graphql.provider.dxm.DataFetchingException;
 import org.jahia.osgi.BundleUtils;
 import org.jahia.services.content.JCRNodeWrapper;
@@ -182,6 +183,11 @@ public class GqlCustomGptAdminMutationResult {
         } catch (RepositoryException e) {
             throw new DataFetchingException(e);
         }
+        // The base URL travels with the Bearer token on every API call; reject anything that is not https to
+        // prevent the token from being exfiltrated over cleartext or to a non-HTTP scheme.
+        if (apiBaseUrl != null && !apiBaseUrl.isEmpty() && !SecurityUtils.isHttpsUrl(apiBaseUrl)) {
+            throw new DataFetchingException(new IllegalArgumentException("apiBaseUrl must be a valid https:// URL"));
+        }
         try {
             final ConfigurationAdmin configAdmin = BundleUtils.getOsgiService(ConfigurationAdmin.class, null);
             if (configAdmin == null) {
@@ -199,11 +205,13 @@ public class GqlCustomGptAdminMutationResult {
                 props.put("org.jahia.community.modules.customgpt.operations.batch.size", operationsBatchSize);
             }
             putIfNotNull(props, "org.jahia.community.modules.customgpt.projectId", projectId);
-            putIfNotNull(props, "org.jahia.community.modules.customgpt.token", token);
+            // Secrets: persist only when the admin actually supplied a new value. A blank or the masking
+            // placeholder echoed back from the settings query leaves the stored secret untouched.
+            putSecretIfChanged(props, "org.jahia.community.modules.customgpt.token", token);
             putIfNotNull(props, "org.jahia.community.modules.customgpt.jahia.username", jahiaUsername);
-            putIfNotNull(props, "org.jahia.community.modules.customgpt.jahia.password", jahiaPassword);
+            putSecretIfChanged(props, "org.jahia.community.modules.customgpt.jahia.password", jahiaPassword);
             putIfNotNull(props, "org.jahia.community.modules.customgpt.jahia.serverCookie.name", jahiaServerCookieName);
-            putIfNotNull(props, "org.jahia.community.modules.customgpt.jahia.serverCookie.value", jahiaServerCookieValue);
+            putSecretIfChanged(props, "org.jahia.community.modules.customgpt.jahia.serverCookie.value", jahiaServerCookieValue);
             putIfNotNull(props, "org.jahia.community.modules.customgpt.jahia.serverCookie.domain", jahiaServerCookieDomain);
             if (dryRun != null) {
                 props.put("org.jahia.community.modules.customgpt.dryRun", dryRun);
@@ -245,6 +253,18 @@ public class GqlCustomGptAdminMutationResult {
 
     private void putIfNotNull(java.util.Dictionary<String, Object> props, String key, String value) {
         if (value != null) {
+            props.put(key, value);
+        }
+    }
+
+    /**
+     * Persists a secret unless the caller did not really change it. {@code null} (field omitted) and the masking
+     * placeholder (see {@link org.jahia.community.modules.customgpt.util.SecurityUtils#SECRET_PLACEHOLDER}, echoed
+     * back unchanged by the UI) both leave the stored secret untouched. An explicit empty string is persisted so a
+     * secret can still be cleared.
+     */
+    private void putSecretIfChanged(java.util.Dictionary<String, Object> props, String key, String value) {
+        if (value != null && !SecurityUtils.isMaskedPlaceholder(value)) {
             props.put(key, value);
         }
     }

--- a/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/query/AdminQueries.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/query/AdminQueries.java
@@ -12,6 +12,7 @@ import org.jahia.community.modules.customgpt.graphql.extensions.models.GqlSiteLi
 import org.jahia.community.modules.customgpt.service.Service;
 import org.jahia.community.modules.customgpt.service.models.Site;
 import org.jahia.community.modules.customgpt.settings.Config;
+import org.jahia.community.modules.customgpt.util.SecurityUtils;
 import org.jahia.modules.graphql.provider.dxm.DataFetchingException;
 import org.jahia.osgi.BundleUtils;
 import org.jahia.services.content.JCRSessionFactory;
@@ -70,11 +71,12 @@ public class AdminQueries {
                     .operationsBatchSize(config.getBulkOperationsBatchSize())
                     .projectId(config.getCustomGptProjectId())
                     .projectName(projectName)
-                    .token(config.getCustomGptToken())
+                    // Secrets are write-only: never echo the stored value back to the client, only whether one is set.
+                    .token(SecurityUtils.maskSecretForDisplay(config.getCustomGptToken()))
                     .jahiaUsername(config.getJahiaUsername())
-                    .jahiaPassword(config.getJahiaPassword())
+                    .jahiaPassword(SecurityUtils.maskSecretForDisplay(config.getJahiaPassword()))
                     .jahiaServerCookieName(config.getJahiaServerCookieName())
-                    .jahiaServerCookieValue(config.getJahiaServerCookieValue())
+                    .jahiaServerCookieValue(SecurityUtils.maskSecretForDisplay(config.getJahiaServerCookieValue()))
                     .jahiaServerCookieDomain(config.getJahiaServerCookieDomain())
                     .dryRun(config.isDryRun())
                     .scheduleJobASAP(config.isScheduleJobASAP())

--- a/src/main/java/org/jahia/community/modules/customgpt/indexer/CustomGptIndexerNodeHandler.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/indexer/CustomGptIndexerNodeHandler.java
@@ -30,6 +30,7 @@ import org.jahia.community.modules.customgpt.settings.Config;
 import org.jahia.community.modules.customgpt.settings.NotConfiguredException;
 import org.jahia.community.modules.customgpt.util.HttpServletRequestMock;
 import org.jahia.community.modules.customgpt.util.HttpServletResponseMock;
+import org.jahia.community.modules.customgpt.util.SecurityUtils;
 import org.jahia.community.modules.customgpt.util.Utils;
 import org.jahia.services.content.JCRCallback;
 import org.jahia.services.content.JCRNodeWrapper;
@@ -339,8 +340,14 @@ final class CustomGptIndexerNodeHandler {
                 .addHeader(HEADER_CONTENT_TYPE, "text/html;charset=UTF-8");
 
         if (StringUtils.isNotEmpty(config.getJahiaUsername()) && StringUtils.isNotEmpty(config.getJahiaPassword())) {
-            String credential = Credentials.basic(config.getJahiaUsername(), config.getJahiaPassword(), StandardCharsets.UTF_8);
-            requestBuilder.addHeader("Authorization", credential);
+            // Only attach Basic auth over HTTPS — the URL host comes from the site's sitemapIndexURL property, which
+            // may be http://; sending the Jahia password over cleartext would expose it on the wire.
+            if (SecurityUtils.isHttpsUrl(url)) {
+                String credential = Credentials.basic(config.getJahiaUsername(), config.getJahiaPassword(), StandardCharsets.UTF_8);
+                requestBuilder.addHeader("Authorization", credential);
+            } else {
+                LOGGER.warn("Skipping Basic authentication for non-https rendering URL to avoid sending credentials in cleartext: {}", url);
+            }
         }
 
         final Request request = requestBuilder.build();

--- a/src/main/java/org/jahia/community/modules/customgpt/service/Service.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/service/Service.java
@@ -588,6 +588,10 @@ public class Service implements EventHandler {
                         .cookieJar(cookieJar)
                         .build();
                 customGptClient = new OkHttpClient.Builder()
+                        // Do not follow redirects: every request carries the Bearer token, and a redirect to another
+                        // host could forward the Authorization header to an attacker-controlled endpoint.
+                        .followRedirects(false)
+                        .followSslRedirects(false)
                         .authenticator((route, response) -> {
                             if (response.request().header(HEADER_AUTHORIZATION) != null) {
                                 return null;

--- a/src/main/java/org/jahia/community/modules/customgpt/util/SecurityUtils.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/util/SecurityUtils.java
@@ -1,0 +1,69 @@
+package org.jahia.community.modules.customgpt.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Pure (no JCR / no OSGi) security helpers shared by the GraphQL layer and the indexer.
+ *
+ * <p>Two concerns are handled here:
+ * <ul>
+ *   <li><b>Write-only secrets.</b> Stored secrets (the CustomGPT token, the Jahia rendering password and the
+ *       server-cookie value) must never be echoed back to a client. {@link #maskSecretForDisplay(String)} replaces
+ *       a stored value with {@link #SECRET_PLACEHOLDER}, and {@link #isUnchangedSecret(String)} lets the save path
+ *       recognise that sentinel (or a blank) and leave the stored value untouched.</li>
+ *   <li><b>Transport safety.</b> {@link #isHttpsUrl(String)} gates anything that carries a credential (the
+ *       configurable CustomGPT {@code apiBaseUrl} that travels with the Bearer token, and the Jahia page URL that
+ *       travels with Basic auth) so secrets never leave over cleartext or a non-URL scheme.</li>
+ * </ul>
+ */
+public final class SecurityUtils {
+
+    /**
+     * Sentinel returned in place of a stored secret. Fixed-length, ASCII, and deliberately not a plausible real
+     * secret so the save path can detect "the admin did not change this field" without ever seeing the real value.
+     */
+    public static final String SECRET_PLACEHOLDER = "********";
+
+    private static final String SCHEME_HTTPS = "https";
+
+    private SecurityUtils() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Returns the placeholder when a secret is set, or an empty string when it is not. Never returns the real value,
+     * so a stored secret cannot be read back through the API.
+     */
+    public static String maskSecretForDisplay(String storedSecret) {
+        return StringUtils.isEmpty(storedSecret) ? "" : SECRET_PLACEHOLDER;
+    }
+
+    /**
+     * Returns {@code true} when an incoming secret value is the masking placeholder echoed back unchanged by the UI.
+     * Such a value must never be persisted (it would overwrite the real secret with {@code ********}); callers skip
+     * writing the property so the stored secret is preserved. An explicit empty string is NOT a placeholder — it
+     * still means "clear this secret".
+     */
+    public static boolean isMaskedPlaceholder(String incoming) {
+        return SECRET_PLACEHOLDER.equals(incoming);
+    }
+
+    /**
+     * Validates that {@code url} is an absolute {@code https://} URL with a host. Used to gate the configurable
+     * CustomGPT API base URL (which is sent together with the Bearer token) so the token cannot be exfiltrated over
+     * cleartext or to a non-HTTP scheme.
+     */
+    public static boolean isHttpsUrl(String url) {
+        if (StringUtils.isEmpty(url)) {
+            return false;
+        }
+        try {
+            final URI uri = new URI(url.trim());
+            return SCHEME_HTTPS.equalsIgnoreCase(uri.getScheme()) && StringUtils.isNotEmpty(uri.getHost());
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/org/jahia/community/modules/customgpt/util/SecurityUtilsTest.java
+++ b/src/test/java/org/jahia/community/modules/customgpt/util/SecurityUtilsTest.java
@@ -1,0 +1,95 @@
+package org.jahia.community.modules.customgpt.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link SecurityUtils} — the write-only-secret masking contract and the HTTPS gate that protects
+ * credentials in transit. These three behaviours back the security fixes: secrets are never echoed back
+ * ({@code maskSecretForDisplay}), an echoed/blank secret is never persisted over the stored one
+ * ({@code isUnchangedSecret}), and credential-bearing URLs must be HTTPS ({@code isHttpsUrl}).
+ */
+class SecurityUtilsTest {
+
+    @Nested
+    @DisplayName("maskSecretForDisplay")
+    class MaskSecretForDisplay {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @DisplayName("returns empty string when no secret is stored")
+        void emptyWhenNotSet(String stored) {
+            assertThat(SecurityUtils.maskSecretForDisplay(stored)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("returns the placeholder (never the real value) when a secret is stored")
+        void placeholderWhenSet() {
+            assertThat(SecurityUtils.maskSecretForDisplay("sk-super-secret-token"))
+                    .isEqualTo(SecurityUtils.SECRET_PLACEHOLDER)
+                    .doesNotContain("secret");
+        }
+    }
+
+    @Nested
+    @DisplayName("isMaskedPlaceholder")
+    class IsMaskedPlaceholder {
+
+        @Test
+        @DisplayName("recognises the placeholder echoed back by the UI (must not be persisted)")
+        void placeholderIsRecognised() {
+            assertThat(SecurityUtils.isMaskedPlaceholder(SecurityUtils.SECRET_PLACEHOLDER)).isTrue();
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @DisplayName("null and empty are NOT the placeholder (empty still means 'clear the secret')")
+        void blankIsNotPlaceholder(String incoming) {
+            assertThat(SecurityUtils.isMaskedPlaceholder(incoming)).isFalse();
+        }
+
+        @Test
+        @DisplayName("a genuinely new value is not the placeholder (persist it)")
+        void newValueIsNotPlaceholder() {
+            assertThat(SecurityUtils.isMaskedPlaceholder("a-brand-new-token")).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("isHttpsUrl")
+    class IsHttpsUrl {
+
+        @Test
+        @DisplayName("accepts a well-formed https URL with a host")
+        void acceptsHttps() {
+            assertThat(SecurityUtils.isHttpsUrl("https://app.customgpt.ai/api/v1")).isTrue();
+        }
+
+        @Test
+        @DisplayName("is case-insensitive on the scheme and tolerates surrounding whitespace")
+        void acceptsHttpsCaseAndTrim() {
+            assertThat(SecurityUtils.isHttpsUrl("  HTTPS://app.customgpt.ai/api/v1  ")).isTrue();
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {
+            "http://app.customgpt.ai/api/v1", // cleartext — token would leak on the wire
+            "ftp://app.customgpt.ai",
+            "https://",                       // no host
+            "app.customgpt.ai/api/v1",        // no scheme
+            "not a url",
+            "file:///etc/passwd"
+        })
+        @DisplayName("rejects non-https, host-less, scheme-less and malformed URLs")
+        void rejectsEverythingElse(String url) {
+            assertThat(SecurityUtils.isHttpsUrl(url)).isFalse();
+        }
+    }
+}

--- a/tests/cypress/e2e/01-customGptSettings.cy.ts
+++ b/tests/cypress/e2e/01-customGptSettings.cy.ts
@@ -103,11 +103,14 @@ describe('CustomGPT.ai Settings', () => {
                     expect(s.contentIndexedFileExtensions).to.eq('pdf,docx');
                     expect(s.operationsBatchSize).to.eq(100);
                     expect(s.projectId).to.eq(Cypress.env('CUSTOMGPT_PROJECT_ID'));
-                    expect(s.token).to.eq(Cypress.env('CUSTOMGPT_TOKEN'));
+                    // Secrets are write-only: a stored value is masked, never echoed back in cleartext (SECURITY-746).
+                    expect(s.token).to.eq('********');
+                    expect(s.token).to.not.eq(Cypress.env('CUSTOMGPT_TOKEN'));
                     expect(s.jahiaUsername).to.eq('root');
-                    expect(s.jahiaPassword).to.eq(Cypress.env('SUPER_USER_PASSWORD'));
+                    expect(s.jahiaPassword).to.eq('********');
+                    expect(s.jahiaPassword).to.not.eq(Cypress.env('SUPER_USER_PASSWORD'));
                     expect(s.jahiaServerCookieName).to.eq('roundtrip-cookie');
-                    expect(s.jahiaServerCookieValue).to.eq('roundtrip-value');
+                    expect(s.jahiaServerCookieValue).to.eq('********');
                     expect(s.jahiaServerCookieDomain).to.eq('roundtrip.local');
                     expect(s.dryRun).to.eq(false);
                     // scheduleJobASAP is a one-shot trigger: the service resets it to
@@ -141,6 +144,18 @@ describe('CustomGPT.ai Settings', () => {
                     expect(s.projectId).to.be.empty;
                     expect(s.token).to.be.empty;
                 });
+        });
+
+        it('rejects a non-https apiBaseUrl (the Bearer token must never travel over cleartext)', () => {
+            // GraphQL errors are caught and yielded by cy.apollo instead of failing the test.
+            cy.apollo({
+                mutation: saveSettings,
+                variables: {apiBaseUrl: 'http://insecure.example.com/api'}
+            }).should(result => {
+                const graphQLErrors = (result && result.graphQLErrors) || [];
+                const errors = (result && result.errors) || [];
+                expect(graphQLErrors.length + errors.length, JSON.stringify(result)).to.be.greaterThan(0);
+            });
         });
     });
 


### PR DESCRIPTION
Hardening of the CustomGPT.ai admin integration:

- F1 (HIGH): secrets are now write-only. The settings GraphQL query returned the CustomGPT token, the Jahia rendering password and the server-cookie value in cleartext on every admin page load. getSettings now returns a masking placeholder via SecurityUtils.maskSecretForDisplay, and saveSettings persists a secret only via putSecretIfChanged: a null field or the placeholder echoed back unchanged leaves the stored secret intact, while an explicit empty string still clears it.
- F2 (MEDIUM): saveSettings rejects any non-https apiBaseUrl, since that URL travels with the Bearer token on every API call.
- F3 (MEDIUM): getJahiaPageContent attaches Basic auth only when the rendering URL (derived from the site sitemapIndexURL, which may be http) is HTTPS; otherwise it logs and skips.
- F4 (LOW): customGptClient no longer follows redirects, so the Authorization header cannot be forwarded to a redirect target.

Adds SecurityUtils (pure helpers) with JUnit 5 + AssertJ unit tests (17 cases). Updates the Cypress settings spec to assert the write-only contract (secrets round-trip as the mask, not cleartext) and adds a negative test for the non-https apiBaseUrl rejection. Documents the invariants in AGENTS.md.