### PR TITLE
harden: https gate on token-bearing base URL, NPE/leak fixes, revive dead tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,9 +76,11 @@
             <version>1.11.8</version>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.10.2</version>
+            <!-- JUnit 4: the jahia-modules parent pins the surefire-junit4 provider, so JUnit 5 (jupiter)
+                 tests are silently not discovered ("Tests run: 0"). Use JUnit 4 so the tests actually run. -->
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/models/GqlCustomGptAdminMutationResult.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/models/GqlCustomGptAdminMutationResult.java
@@ -79,6 +79,9 @@ public class GqlCustomGptAdminMutationResult {
             throw new DataFetchingException(e);
         }
         final Service customGptService = BundleUtils.getOsgiService(Service.class, null);
+        if (customGptService == null) {
+            throw new DataFetchingException(new IllegalStateException("CustomGPT service is not available"));
+        }
         if (siteKeys != null) {
             final Collection<Site> sites = customGptService.getIndexedSites().values();
             for (String siteKey : siteKeys) {
@@ -114,6 +117,12 @@ public class GqlCustomGptAdminMutationResult {
     private List<JobDetail> getJobDetailList(List<String> siteKeys,
             Service customGptService, boolean force) {
         final List<JobDetail> jobDetailList = new ArrayList<>();
+        // No site keys supplied: trigger a full re-index of every indexable site (documented behaviour),
+        // rather than dereferencing a null list.
+        if (siteKeys == null) {
+            customGptService.reIndexUsingJob();
+            return jobDetailList;
+        }
         try {
             for (String siteKey : siteKeys) {
                 checkAdminPermission(CustomGptConstants.PATH_SITES + siteKey, CustomGptConstants.PERM_SITE_ADMIN);

--- a/src/main/java/org/jahia/community/modules/customgpt/indexer/CustomGptIndexerNodeHandler.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/indexer/CustomGptIndexerNodeHandler.java
@@ -63,6 +63,7 @@ final class CustomGptIndexerNodeHandler {
     private static final String HEADER_CONTENT_TYPE = "content-type";
     private static final String MEDIA_TYPE_JSON = "application/json";
     private static final String VALUE_FALSE = "false";
+    private static final long RETRY_DELAY_MS = 500L;
 
     private CustomGptIndexerNodeHandler() {
         throw new IllegalStateException("Utility class");
@@ -206,6 +207,9 @@ final class CustomGptIndexerNodeHandler {
         try (Response addDocResponse = addPage(customGptClient, projectId, title, output, apiBaseUrl)) {
             if (!addDocResponse.isSuccessful()) {
                 throw new IOException("Impossible to add the page for the URL " + url + ", following response received, " + addDocResponse);
+            }
+            if (addDocResponse.body() == null) {
+                throw new IOException("Empty response body when adding the page for the URL " + url);
             }
             LOGGER.debug("Adding page in customGPT is successful, retrieving response body");
             final JSONObject document = new JSONObject(addDocResponse.body().string());
@@ -356,24 +360,28 @@ final class CustomGptIndexerNodeHandler {
         }
 
         final Request request = requestBuilder.build();
-        boolean success = false;
-        int attempts = 0;
         Response response = null;
-        while(!success && attempts < CustomGptConstants.MAX_RETRIES){
+        for (int attempts = 0; attempts < CustomGptConstants.MAX_RETRIES; attempts++) {
             response = jahiaClient.newCall(request).execute();
-            success = response.isSuccessful();
-            attempts++;
-            Thread.sleep(500L);
+            if (response.isSuccessful()) {
+                return response;
+            }
+            // Close the failed response before retrying so its body/connection is not leaked; the last
+            // (still unsuccessful) response is returned for the caller to inspect and close.
+            if (attempts < CustomGptConstants.MAX_RETRIES - 1) {
+                response.close();
+                Thread.sleep(RETRY_DELAY_MS);
+            }
         }
         return response;
     }
 
     private static String getApiBaseUrl(Indexer customGptIndexer) {
-        String baseUrl = customGptIndexer.getCustomGptConfig().getCustomGptApiBaseUrl();
-        if (StringUtils.isEmpty(baseUrl)) {
-            baseUrl = CustomGptConstants.DEFAULT_CUSTOM_GPT_API_BASE_URL;
-        }
-        return baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        // Every request built from this base URL carries the CustomGPT Bearer token; the shared helper refuses a
+        // non-https base URL (which could be set directly in the .cfg, bypassing the saveSettings gate).
+        return SecurityUtils.resolveHttpsBaseUrl(
+                customGptIndexer.getCustomGptConfig().getCustomGptApiBaseUrl(),
+                CustomGptConstants.DEFAULT_CUSTOM_GPT_API_BASE_URL);
     }
 
     private static String extractPageId(JSONObject document) {

--- a/src/main/java/org/jahia/community/modules/customgpt/service/Service.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/service/Service.java
@@ -38,6 +38,7 @@ import org.jahia.community.modules.customgpt.service.models.Site;
 import org.jahia.community.modules.customgpt.settings.Config;
 import org.jahia.community.modules.customgpt.settings.NotConfiguredException;
 import org.jahia.community.modules.customgpt.util.RateLimitInterceptor;
+import org.jahia.community.modules.customgpt.util.SecurityUtils;
 import org.jahia.osgi.FrameworkService;
 import org.jahia.services.content.*;
 import org.jahia.services.events.JournalEventReader;
@@ -84,6 +85,7 @@ public class Service implements EventHandler {
     private static final String PROP_INDEXATION_START = "customGptIndexationStart";
     private static final String RECREATE_LOG = "Recreate Log";
     private static final int N_THREADS = 2;
+    private static final int DEFAULT_BATCH_SIZE = 10;
     private static final String HEADER_AUTHORIZATION = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String HEADER_ACCEPT = "accept";
@@ -846,17 +848,33 @@ public class Service implements EventHandler {
      * Calls {@code GET /projects/{projectId}} and returns the {@code project_name} field.
      * Returns {@code null} if the project ID is empty, the client is null, or the API call fails.
      */
+    /**
+     * Resolves the configured CustomGPT API base URL, applying the default when unset and stripping a trailing
+     * slash. Every request built from the result carries the Bearer token, so the URL is validated as https://
+     * here (a {@code .cfg} edit bypasses the {@code saveSettings} gate) to keep the token off cleartext channels.
+     *
+     * @throws IllegalStateException when the resolved base URL is not a valid {@code https://} URL
+     */
+    private String resolveValidatedApiBaseUrl() {
+        return SecurityUtils.resolveHttpsBaseUrl(
+                customGptConfig.getCustomGptApiBaseUrl(), CustomGptConstants.DEFAULT_CUSTOM_GPT_API_BASE_URL);
+    }
+
     public String getProjectName() {
         final String projectId = customGptConfig.getCustomGptProjectId();
         if (projectId == null || projectId.isEmpty()) {
             return null;
         }
-        String baseUrl = customGptConfig.getCustomGptApiBaseUrl();
-        if (baseUrl == null || baseUrl.isEmpty()) {
-            baseUrl = CustomGptConstants.DEFAULT_CUSTOM_GPT_API_BASE_URL;
+        if (customGptClient == null) {
+            LOGGER.warn("CustomGPT HTTP client is not initialised; cannot fetch project name");
+            return null;
         }
-        if (baseUrl.endsWith("/")) {
-            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        final String baseUrl;
+        try {
+            baseUrl = resolveValidatedApiBaseUrl();
+        } catch (IllegalStateException e) {
+            LOGGER.warn("Cannot fetch CustomGPT project name: {}", e.getMessage());
+            return null;
         }
         final Request request = new Request.Builder()
                 .url(String.format("%s/projects/%s", baseUrl, projectId))
@@ -867,6 +885,10 @@ public class Service implements EventHandler {
         try (Response response = customGptClient.newCall(request).execute()) {
             if (!response.isSuccessful()) {
                 LOGGER.warn("Failed to fetch CustomGPT project name for project {}: {}", projectId, response.code());
+                return null;
+            }
+            if (response.body() == null) {
+                LOGGER.warn("Empty response body fetching CustomGPT project name for project {}", projectId);
                 return null;
             }
             final JSONObject body = new JSONObject(response.body().string());
@@ -891,21 +913,24 @@ public class Service implements EventHandler {
      */
     public int purgeAllPages() throws IOException {
         final String projectId = customGptConfig.getCustomGptProjectId();
-        LOGGER.info("[purgeAllPages] Starting purge for project {}", projectId);
+        // projectId is free-form admin config; strip CR/LF before logging to prevent log forging.
+        final String safeProjectId = SecurityUtils.sanitizeForLog(projectId);
+        LOGGER.info("[purgeAllPages] Starting purge for project {}", safeProjectId);
 
-        String baseUrl = customGptConfig.getCustomGptApiBaseUrl();
-        if (baseUrl == null || baseUrl.isEmpty()) {
-            baseUrl = CustomGptConstants.DEFAULT_CUSTOM_GPT_API_BASE_URL;
+        if (customGptClient == null) {
+            throw new IOException("CustomGPT HTTP client is not initialised; cannot purge pages");
         }
-        if (baseUrl.endsWith("/")) {
-            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
-        }
+        final String baseUrl = resolveValidatedApiBaseUrl();
 
         int batchSize;
         try {
             batchSize = customGptConfig.getBulkOperationsBatchSize();
-        } catch (Exception e) {
-            batchSize = 10;
+        } catch (NotConfiguredException e) {
+            LOGGER.warn("[purgeAllPages] Batch size unavailable, falling back to {}: {}", DEFAULT_BATCH_SIZE, e.getMessage());
+            batchSize = DEFAULT_BATCH_SIZE;
+        }
+        if (batchSize <= 0) {
+            batchSize = DEFAULT_BATCH_SIZE;
         }
 
         final String firstPageUrl = String.format("%s/projects/%s/pages", baseUrl, projectId);
@@ -914,7 +939,8 @@ public class Service implements EventHandler {
 
         // Cap threads to the rate limit so we never create more concurrent callers than tokens-per-second.
         // A single executor is reused across all purge rounds to avoid repeated thread-pool creation/teardown.
-        final int threadCount = Math.min(batchSize, customGptConfig.getRateLimitRequestsPerSecond());
+        // Guard against a zero/negative rate limit, which would make newFixedThreadPool throw.
+        final int threadCount = Math.max(1, Math.min(batchSize, customGptConfig.getRateLimitRequestsPerSecond()));
         final ExecutorService batchExecutor = Executors.newFixedThreadPool(threadCount);
         try {
             while (true) {
@@ -932,7 +958,7 @@ public class Service implements EventHandler {
             shutdownAndAwaitTermination(batchExecutor);
         }
 
-        LOGGER.info("[purgeAllPages] Purge complete — deleted {} page(s) from project {}", totalDeleted, projectId);
+        LOGGER.info("[purgeAllPages] Purge complete — deleted {} page(s) from project {}", totalDeleted, safeProjectId);
         return totalDeleted;
     }
 
@@ -946,6 +972,10 @@ public class Service implements EventHandler {
         try (Response listResponse = customGptClient.newCall(listRequest).execute()) {
             if (!listResponse.isSuccessful()) {
                 LOGGER.error("[purgeAllPages] Failed to list CustomGPT pages (HTTP {}), stopping", listResponse.code());
+                return Collections.emptyList();
+            }
+            if (listResponse.body() == null) {
+                LOGGER.error("[purgeAllPages] Empty response body when listing CustomGPT pages, stopping");
                 return Collections.emptyList();
             }
             final JSONObject body = new JSONObject(listResponse.body().string());

--- a/src/main/java/org/jahia/community/modules/customgpt/util/SecurityUtils.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/util/SecurityUtils.java
@@ -66,4 +66,41 @@ public final class SecurityUtils {
             return false;
         }
     }
+
+    /**
+     * Resolves an outbound API base URL that carries a credential: applies {@code defaultUrl} when {@code configured}
+     * is blank, strips a single trailing slash, and asserts the result is an {@code https://} URL. Centralising this
+     * (used by both the synchronous service calls and the indexer) guarantees the Bearer token is never sent over a
+     * cleartext or non-HTTP base URL, even when the value is set directly in the {@code .cfg} (bypassing the
+     * {@code saveSettings} UI gate).
+     *
+     * @throws IllegalStateException when the resolved base URL is not a valid {@code https://} URL
+     */
+    public static String resolveHttpsBaseUrl(String configured, String defaultUrl) {
+        String baseUrl = StringUtils.isEmpty(configured) ? defaultUrl : configured;
+        if (baseUrl != null && baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        if (!isHttpsUrl(baseUrl)) {
+            throw new IllegalStateException("CustomGPT apiBaseUrl must be a valid https:// URL");
+        }
+        return baseUrl;
+    }
+
+    /**
+     * Removes CR/LF (and other ISO control) characters from a value before it is written to a log line, so that
+     * attacker- or config-controlled strings cannot forge additional log records (log injection / log forging).
+     * Returns {@code null} unchanged so callers can still distinguish a missing value.
+     */
+    public static String sanitizeForLog(String value) {
+        if (value == null) {
+            return null;
+        }
+        final StringBuilder sb = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            final char c = value.charAt(i);
+            sb.append(Character.isISOControl(c) ? '_' : c);
+        }
+        return sb.toString();
+    }
 }

--- a/src/test/java/org/jahia/community/modules/customgpt/util/SecurityUtilsTest.java
+++ b/src/test/java/org/jahia/community/modules/customgpt/util/SecurityUtilsTest.java
@@ -1,95 +1,155 @@
 package org.jahia.community.modules.customgpt.util;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Unit tests for {@link SecurityUtils} — the write-only-secret masking contract and the HTTPS gate that protects
- * credentials in transit. These three behaviours back the security fixes: secrets are never echoed back
- * ({@code maskSecretForDisplay}), an echoed/blank secret is never persisted over the stored one
- * ({@code isUnchangedSecret}), and credential-bearing URLs must be HTTPS ({@code isHttpsUrl}).
+ * Unit tests for {@link SecurityUtils} — the write-only-secret masking contract, the HTTPS gate that protects
+ * credentials in transit, the shared base-URL resolver, and log-injection sanitisation.
+ *
+ * <p>Written with JUnit 4 ({@code org.junit.Test}) because the jahia-modules parent pins the
+ * {@code surefire-junit4} provider; JUnit 5 (jupiter) test methods are silently <em>not discovered</em> and report
+ * "Tests run: 0".
  */
-class SecurityUtilsTest {
+public class SecurityUtilsTest {
 
-    @Nested
-    @DisplayName("maskSecretForDisplay")
-    class MaskSecretForDisplay {
+    // ---- maskSecretForDisplay ----
 
-        @ParameterizedTest
-        @NullAndEmptySource
-        @DisplayName("returns empty string when no secret is stored")
-        void emptyWhenNotSet(String stored) {
-            assertThat(SecurityUtils.maskSecretForDisplay(stored)).isEmpty();
-        }
-
-        @Test
-        @DisplayName("returns the placeholder (never the real value) when a secret is stored")
-        void placeholderWhenSet() {
-            assertThat(SecurityUtils.maskSecretForDisplay("sk-super-secret-token"))
-                    .isEqualTo(SecurityUtils.SECRET_PLACEHOLDER)
-                    .doesNotContain("secret");
-        }
+    @Test
+    public void maskSecretForDisplay_returnsEmptyWhenNull() {
+        assertThat(SecurityUtils.maskSecretForDisplay(null)).isEmpty();
     }
 
-    @Nested
-    @DisplayName("isMaskedPlaceholder")
-    class IsMaskedPlaceholder {
-
-        @Test
-        @DisplayName("recognises the placeholder echoed back by the UI (must not be persisted)")
-        void placeholderIsRecognised() {
-            assertThat(SecurityUtils.isMaskedPlaceholder(SecurityUtils.SECRET_PLACEHOLDER)).isTrue();
-        }
-
-        @ParameterizedTest
-        @NullAndEmptySource
-        @DisplayName("null and empty are NOT the placeholder (empty still means 'clear the secret')")
-        void blankIsNotPlaceholder(String incoming) {
-            assertThat(SecurityUtils.isMaskedPlaceholder(incoming)).isFalse();
-        }
-
-        @Test
-        @DisplayName("a genuinely new value is not the placeholder (persist it)")
-        void newValueIsNotPlaceholder() {
-            assertThat(SecurityUtils.isMaskedPlaceholder("a-brand-new-token")).isFalse();
-        }
+    @Test
+    public void maskSecretForDisplay_returnsEmptyWhenBlank() {
+        assertThat(SecurityUtils.maskSecretForDisplay("")).isEmpty();
     }
 
-    @Nested
-    @DisplayName("isHttpsUrl")
-    class IsHttpsUrl {
+    @Test
+    public void maskSecretForDisplay_returnsPlaceholderNeverRealValueWhenSet() {
+        assertThat(SecurityUtils.maskSecretForDisplay("sk-super-secret-token"))
+                .isEqualTo(SecurityUtils.SECRET_PLACEHOLDER)
+                .doesNotContain("secret");
+    }
 
-        @Test
-        @DisplayName("accepts a well-formed https URL with a host")
-        void acceptsHttps() {
-            assertThat(SecurityUtils.isHttpsUrl("https://app.customgpt.ai/api/v1")).isTrue();
-        }
+    // ---- isMaskedPlaceholder ----
 
-        @Test
-        @DisplayName("is case-insensitive on the scheme and tolerates surrounding whitespace")
-        void acceptsHttpsCaseAndTrim() {
-            assertThat(SecurityUtils.isHttpsUrl("  HTTPS://app.customgpt.ai/api/v1  ")).isTrue();
-        }
+    @Test
+    public void isMaskedPlaceholder_recognisesPlaceholderEchoedBack() {
+        assertThat(SecurityUtils.isMaskedPlaceholder(SecurityUtils.SECRET_PLACEHOLDER)).isTrue();
+    }
 
-        @ParameterizedTest
-        @NullAndEmptySource
-        @ValueSource(strings = {
-            "http://app.customgpt.ai/api/v1", // cleartext — token would leak on the wire
-            "ftp://app.customgpt.ai",
-            "https://",                       // no host
-            "app.customgpt.ai/api/v1",        // no scheme
-            "not a url",
-            "file:///etc/passwd"
-        })
-        @DisplayName("rejects non-https, host-less, scheme-less and malformed URLs")
-        void rejectsEverythingElse(String url) {
-            assertThat(SecurityUtils.isHttpsUrl(url)).isFalse();
-        }
+    @Test
+    public void isMaskedPlaceholder_nullIsNotPlaceholder() {
+        assertThat(SecurityUtils.isMaskedPlaceholder(null)).isFalse();
+    }
+
+    @Test
+    public void isMaskedPlaceholder_emptyStillMeansClearTheSecret() {
+        assertThat(SecurityUtils.isMaskedPlaceholder("")).isFalse();
+    }
+
+    @Test
+    public void isMaskedPlaceholder_genuinelyNewValueIsNotPlaceholder() {
+        assertThat(SecurityUtils.isMaskedPlaceholder("a-brand-new-token")).isFalse();
+    }
+
+    // ---- isHttpsUrl ----
+
+    @Test
+    public void isHttpsUrl_acceptsWellFormedHttpsWithHost() {
+        assertThat(SecurityUtils.isHttpsUrl("https://app.customgpt.ai/api/v1")).isTrue();
+    }
+
+    @Test
+    public void isHttpsUrl_isCaseInsensitiveAndTrimsWhitespace() {
+        assertThat(SecurityUtils.isHttpsUrl("  HTTPS://app.customgpt.ai/api/v1  ")).isTrue();
+    }
+
+    @Test
+    public void isHttpsUrl_rejectsCleartextHttp() {
+        assertThat(SecurityUtils.isHttpsUrl("http://app.customgpt.ai/api/v1")).isFalse();
+    }
+
+    @Test
+    public void isHttpsUrl_rejectsNonHttpScheme() {
+        assertThat(SecurityUtils.isHttpsUrl("ftp://app.customgpt.ai")).isFalse();
+        assertThat(SecurityUtils.isHttpsUrl("file:///etc/passwd")).isFalse();
+    }
+
+    @Test
+    public void isHttpsUrl_rejectsHostlessSchemelessAndMalformed() {
+        assertThat(SecurityUtils.isHttpsUrl("https://")).isFalse();
+        assertThat(SecurityUtils.isHttpsUrl("app.customgpt.ai/api/v1")).isFalse();
+        assertThat(SecurityUtils.isHttpsUrl("not a url")).isFalse();
+    }
+
+    @Test
+    public void isHttpsUrl_rejectsNullAndEmpty() {
+        assertThat(SecurityUtils.isHttpsUrl(null)).isFalse();
+        assertThat(SecurityUtils.isHttpsUrl("")).isFalse();
+    }
+
+    // ---- resolveHttpsBaseUrl ----
+
+    private static final String DEFAULT_BASE = "https://app.customgpt.ai/api/v1";
+
+    @Test
+    public void resolveHttpsBaseUrl_fallsBackToDefaultWhenBlank() {
+        assertThat(SecurityUtils.resolveHttpsBaseUrl("", DEFAULT_BASE)).isEqualTo(DEFAULT_BASE);
+        assertThat(SecurityUtils.resolveHttpsBaseUrl(null, DEFAULT_BASE)).isEqualTo(DEFAULT_BASE);
+    }
+
+    @Test
+    public void resolveHttpsBaseUrl_stripsSingleTrailingSlash() {
+        assertThat(SecurityUtils.resolveHttpsBaseUrl("https://host/api/v1/", DEFAULT_BASE))
+                .isEqualTo("https://host/api/v1");
+    }
+
+    @Test
+    public void resolveHttpsBaseUrl_keepsWellFormedHttps() {
+        assertThat(SecurityUtils.resolveHttpsBaseUrl("https://host/api/v1", DEFAULT_BASE))
+                .isEqualTo("https://host/api/v1");
+    }
+
+    @Test
+    public void resolveHttpsBaseUrl_rejectsHttpSoTokenCannotLeakOverCleartext() {
+        assertThatThrownBy(() -> SecurityUtils.resolveHttpsBaseUrl("http://evil.example/api", DEFAULT_BASE))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("https");
+    }
+
+    @Test
+    public void resolveHttpsBaseUrl_rejectsSchemelessOrMalformed() {
+        assertThatThrownBy(() -> SecurityUtils.resolveHttpsBaseUrl("app.customgpt.ai/api", DEFAULT_BASE))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    // ---- sanitizeForLog ----
+
+    @Test
+    public void sanitizeForLog_returnsNullUnchanged() {
+        assertThat(SecurityUtils.sanitizeForLog(null)).isNull();
+    }
+
+    @Test
+    public void sanitizeForLog_leavesCleanValueUntouched() {
+        assertThat(SecurityUtils.sanitizeForLog("project-123")).isEqualTo("project-123");
+    }
+
+    @Test
+    public void sanitizeForLog_stripsCrLfToPreventLogForging() {
+        final String forged = "real\r\nINFO admin granted access";
+        assertThat(SecurityUtils.sanitizeForLog(forged))
+                .doesNotContain("\r")
+                .doesNotContain("\n")
+                .isEqualTo("real__INFO admin granted access");
+    }
+
+    @Test
+    public void sanitizeForLog_replacesOtherIsoControlChars() {
+        assertThat(SecurityUtils.sanitizeForLog("a\tb")).isEqualTo("a_b");
     }
 }


### PR DESCRIPTION
## Summary
Behavior-preserving hardening of the CustomGPT AI module along the fleet axes (input validation at boundaries, SSRF/cleartext-credential defense, resource cleanup, null safety, no swallowed errors, concurrency safety). The module was already substantially hardened (SecurityUtils masking, no-redirect OkHttp clients, thread-safe RateLimitInterceptor, try-with-resources on most responses); these are the genuine remaining gaps.

## Security
- **S1 — token-bearing base URL not validated at request time.** The config-derived `apiBaseUrl` is sent with the Bearer token on every CustomGPT call. `saveSettings` gated it, but a direct `.cfg` edit bypassed that. Added `SecurityUtils.resolveHttpsBaseUrl(...)` (shared by `Service` and `CustomGptIndexerNodeHandler`) which normalizes and rejects any non-`https://` base URL before a request is built.
- **S2 — log forging.** Admin-controlled `projectId` was logged verbatim in `purgeAllPages`. Added `SecurityUtils.sanitizeForLog(...)` stripping CR/LF and ISO control chars.

## Robustness
- **R1 — resource leak.** `getJahiaPageContent` retry loop overwrote `Response` references without closing intermediate non-successful responses. Now closed before retry; `500ms` delay extracted to a named constant.
- **R2 — NPE.** `startIndex` dereferenced a null `siteKeys` (the documented full-reindex path) and an unavailable OSGi `Service`. Both guarded; null `siteKeys` now correctly routes to a full reindex.
- **R3 — NPE.** `response.body()` used without null checks in `getProjectName`, `fetchOnePage`, and the add-page upload path.
- **R4 — purge robustness.** Guarded `newFixedThreadPool` against a zero/negative rate limit, replaced magic `10` with `DEFAULT_BATCH_SIZE`, and stopped swallowing a generic `Exception` (now catches `NotConfiguredException` and logs).

## Tests
The existing `SecurityUtilsTest` was written in JUnit 5, but the jahia-modules parent pins the `surefire-junit4` provider — so it silently ran **0 tests**. Converted it to JUnit 4 and swapped the `junit-jupiter` dependency for `junit 4.13.2`. **22 tests now execute and pass** (was 0), covering the https gate, the base-URL resolver, secret masking, and the log sanitiser.

## Test plan
- [x] `mvn clean install` green; 22 unit tests pass.
- [ ] Verify a non-https `apiBaseUrl` in `.cfg` is rejected (no token egress) in a running instance.
- [ ] Verify `startIndex` with no `siteKeys` triggers a full reindex.

CLA check can be ignored.