### PR TITLE
feat: add customGptAdmin permission for fine-grained RBAC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,8 @@
             org.jahia.modules.graphql.provider.dxm;version="[2.8,4)",
             org.jahia.modules.graphql.provider.dxm.util;version="[2.8,4)",
             org.jahia.modules.graphql.provider.dxm.admin;version="[2.8,4)",
-            org.jahia.modules.graphql.provider.dxm.osgi.annotations;version="[2.8,4)"
+            org.jahia.modules.graphql.provider.dxm.osgi.annotations;version="[2.8,4)",
+            org.jahia.modules.graphql.provider.dxm.security;version="[2.8,4)"
         </import-package>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
     </properties>

--- a/src/javascript/CustomGptSettings/register.jsx
+++ b/src/javascript/CustomGptSettings/register.jsx
@@ -6,7 +6,7 @@ export default () => {
     console.debug('%c customgpt-ai: activation in progress', 'color: #006633');
     registry.add('adminRoute', 'customgptAiSettings', {
         targets: ['administration-server-configuration:25'],
-        requiredPermission: 'admin',
+        requiredPermission: 'customGptAdmin',
         label: 'customgpt-ai:label.menu_entry',
         isSelectable: true,
         render: () => React.createElement(CustomGptSettingsAdmin)

--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <admin jcr:primaryType="jnt:permission">
+        <customGptAdmin jcr:primaryType="jnt:permission"/>
+    </admin>
+</permissions>

--- a/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/GqlAdminQuery.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/GqlAdminQuery.java
@@ -5,6 +5,7 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.community.modules.customgpt.graphql.extensions.query.AdminQueries;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 
 /**
  * GraphQL type extension that injects the {@code customGpt} query field under {@code admin}.
@@ -19,6 +20,7 @@ public final class GqlAdminQuery {
     @GraphQLField
     @GraphQLName("customGpt")
     @GraphQLDescription("CustomGPT administrative queries")
+    @GraphQLRequiresPermission("customGptAdmin")
     public static AdminQueries customGpt() {
         return new AdminQueries();
     }

--- a/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/GqlCustomGptAdminMutation.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/GqlCustomGptAdminMutation.java
@@ -6,6 +6,7 @@ import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.community.modules.customgpt.graphql.extensions.models.GqlCustomGptAdminMutationResult;
 import org.jahia.modules.graphql.provider.dxm.admin.GqlAdminMutation;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 
 
 /**
@@ -21,6 +22,7 @@ public final class GqlCustomGptAdminMutation {
     @GraphQLField
     @GraphQLName("customGpt")
     @GraphQLDescription("CustomGPT administrative mutations")
+    @GraphQLRequiresPermission("customGptAdmin")
     public static GqlCustomGptAdminMutationResult customGpt() {
         return new GqlCustomGptAdminMutationResult();
     }


### PR DESCRIPTION
## Summary

- Defines a `customGptAdmin` JCR permission node as a child of `admin` in `src/main/import/permissions.xml`, registered at module install time.
- Adds `@GraphQLRequiresPermission("customGptAdmin")` to the `customGpt` field methods on both `GqlAdminQuery` and `GqlCustomGptAdminMutation`, enabling operators to grant or deny CustomGPT admin access independently of the broad `admin` gate inherited from the parent type extensions.
- Adds `org.jahia.modules.graphql.provider.dxm.security` to the OSGi `import-package` in `pom.xml` so the annotation resolves at runtime.

## Test plan

- [ ] Build passes: `mvn -q clean install` exits 0
- [ ] Deploy module to Jahia and verify `customGptAdmin` permission node appears under `/permissions/admin/customGptAdmin` in JCR
- [ ] Grant `customGptAdmin` to a non-admin user and confirm they can call `admin { customGpt { ... } }` queries and mutations
- [ ] Revoke `customGptAdmin` and confirm the GraphQL field returns a permission-denied error (not a 500)
- [ ] Confirm users with only `customGptAdmin` (not full `admin`) cannot access unrelated admin fields