### PR TITLE
test: add fine-grained permission regression tests + assignable admin role

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.jahia.modules.community</groupId>
     <artifactId>customgpt-ai</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>customGPT.ai</name>
     <description>This module allows the update of customGPT.ai</description>

--- a/src/main/import/roles.xml
+++ b/src/main/import/roles.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<roles jcr:primaryType="jnt:roles"
+       xmlns:jcr="http://www.jcp.org/jcr/1.0"
+       xmlns:j="http://www.jahia.org/jahia/1.0"
+       xmlns:jnt="http://www.jahia.org/jahia/nt/1.0">
+
+    <customgpt-ai-administrator jcr:primaryType="jnt:role"
+                                j:nodeTypes="rep:root"
+                                j:roleGroup="server-role"
+                                j:permissionNames="administrationAccess customGptAdmin"
+                                j:privilegedAccess="true">
+        <j:translation_en jcr:primaryType="jnt:translation"
+                          jcr:language="en"
+                          jcr:title="CustomGPT.ai administrator"
+                          jcr:description="Grants access to the CustomGPT.ai settings administration without requiring full server administrator rights"/>
+    </customgpt-ai-administrator>
+</roles>

--- a/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/models/GqlCustomGptAdminMutationResult.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/models/GqlCustomGptAdminMutationResult.java
@@ -25,14 +25,17 @@ import org.slf4j.LoggerFactory;
 /**
  * GraphQL mutation resolver for the {@code admin.customGpt} namespace.
  * Contains mutations for site management, indexation triggering, settings persistence,
- * and the danger-zone purge operation. All mutations enforce the {@code admin} permission.
+ * and the danger-zone purge operation. All mutations enforce the {@code customGptAdmin} permission
+ * on the root path, matching the field-level {@code @GraphQLRequiresPermission("customGptAdmin")}
+ * annotation so the fine-grained admin role works end-to-end. Per-site operations additionally
+ * enforce the site-scoped {@code site-admin} permission.
  */
 @GraphQLName("CustomGptAdminMutations")
 @GraphQLDescription("Generic object with admin mutation results")
 public class GqlCustomGptAdminMutationResult {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GqlCustomGptAdminMutationResult.class);
-    private static final String ADMIN = "admin";
+    private static final String CUSTOM_GPT_ADMIN = "customGptAdmin";
     private static final String CONFIG_PID = "org.jahia.community.modules.customgpt";
 
     @GraphQLName("Status")
@@ -74,7 +77,7 @@ public class GqlCustomGptAdminMutationResult {
             @GraphQLDefaultValue(DefaultForce.class) boolean force
     ) throws RepositoryException {
         try {
-            checkAdminPermission(CustomGptConstants.PATH_DELIMITER, ADMIN);
+            checkAdminPermission(CustomGptConstants.PATH_DELIMITER, CUSTOM_GPT_ADMIN);
         } catch (RepositoryException e) {
             throw new DataFetchingException(e);
         }
@@ -106,7 +109,7 @@ public class GqlCustomGptAdminMutationResult {
             @GraphQLDescription("Re-index descendants (Optional; default=false)") Boolean inclDescendants
     ) throws RepositoryException {
         try {
-            checkAdminPermission(CustomGptConstants.PATH_DELIMITER, ADMIN);
+            checkAdminPermission(CustomGptConstants.PATH_DELIMITER, CUSTOM_GPT_ADMIN);
         } catch (RepositoryException e) {
             throw new DataFetchingException(e);
         }
@@ -146,7 +149,7 @@ public class GqlCustomGptAdminMutationResult {
     public String addSite(@GraphQLName(CustomGptConstants.PROP_SITE_KEY) @GraphQLNonNull @GraphQLDescription("Site key") String siteKey) {
 
         try {
-            checkAdminPermission(CustomGptConstants.PATH_DELIMITER, ADMIN);
+            checkAdminPermission(CustomGptConstants.PATH_DELIMITER, CUSTOM_GPT_ADMIN);
             return JCRTemplate.getInstance().doExecuteWithSystemSession(session -> {
                 if ("".equals(siteKey)) {
                     throw new RepositoryException("Site '/sites/' does not exist. Provide a valid site key.");
@@ -188,7 +191,7 @@ public class GqlCustomGptAdminMutationResult {
             @GraphQLName("apiBaseUrl") @GraphQLDescription("CustomGPT API base URL") String apiBaseUrl,
             @GraphQLName("rateLimitRequestsPerSecond") @GraphQLDescription("Maximum API requests per second (token-bucket rate limit)") Integer rateLimitRequestsPerSecond) {
         try {
-            checkAdminPermission(CustomGptConstants.PATH_DELIMITER, ADMIN);
+            checkAdminPermission(CustomGptConstants.PATH_DELIMITER, CUSTOM_GPT_ADMIN);
         } catch (RepositoryException e) {
             throw new DataFetchingException(e);
         }
@@ -245,7 +248,7 @@ public class GqlCustomGptAdminMutationResult {
     @GraphQLDescription("Delete all pages from the CustomGPT project and return the number of pages deleted")
     public Integer purgeAllPages() {
         try {
-            checkAdminPermission(CustomGptConstants.PATH_DELIMITER, ADMIN);
+            checkAdminPermission(CustomGptConstants.PATH_DELIMITER, CUSTOM_GPT_ADMIN);
         } catch (RepositoryException e) {
             throw new DataFetchingException(e);
         }

--- a/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/query/AdminQueries.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/query/AdminQueries.java
@@ -20,20 +20,22 @@ import org.jahia.services.content.JCRSessionFactory;
 /**
  * GraphQL query resolver for the {@code admin.customGpt} namespace.
  * Provides access to indexed-site listing and configuration settings.
- * All methods check for the {@code admin} permission on the root path before returning data.
+ * All methods check for the {@code customGptAdmin} permission on the root path before returning data,
+ * matching the field-level {@code @GraphQLRequiresPermission("customGptAdmin")} annotation so the
+ * fine-grained admin role works end-to-end.
  */
 @GraphQLName("CustomGptAdminQueries")
 @GraphQLDescription("List of indexed sites entry point")
 public class AdminQueries {
 
-    private static final String ADMIN = "admin";
+    private static final String CUSTOM_GPT_ADMIN = "customGptAdmin";
 
     @GraphQLField
     @GraphQLName("listSites")
     @GraphQLDescription("List sites configured for CustomGpt")
     public GqlSiteListModel getListSites() {
         try {
-            checkAdminPermission(CustomGptConstants.PATH_DELIMITER, ADMIN);
+            checkAdminPermission(CustomGptConstants.PATH_DELIMITER, CUSTOM_GPT_ADMIN);
         } catch (RepositoryException e) {
             throw new DataFetchingException(e);
         }
@@ -46,7 +48,7 @@ public class AdminQueries {
     @GraphQLDescription("Returns the current CustomGPT configuration settings")
     public GqlSettings getSettings() {
         try {
-            checkAdminPermission(CustomGptConstants.PATH_DELIMITER, ADMIN);
+            checkAdminPermission(CustomGptConstants.PATH_DELIMITER, CUSTOM_GPT_ADMIN);
         } catch (RepositoryException e) {
             throw new DataFetchingException(e);
         }

--- a/tests/cypress/e2e/04-customGpt-Permissions.cy.ts
+++ b/tests/cypress/e2e/04-customGpt-Permissions.cy.ts
@@ -17,15 +17,14 @@ import {createUser, deleteUser, grantRoles} from '@jahia/cypress';
  * The allow path uses the read-only `getSettings` query (no secrets are returned in cleartext;
  * token / passwords / cookie value are masked to `********`), so it is a safe gated op.
  *
- * NOTE on the allow assertion: every `admin.customGpt` resolver currently performs a *second*,
- * hardcoded `node("/").hasPermission("admin")` check on top of the field-level
- * `@GraphQLRequiresPermission("customGptAdmin")` annotation (see AdminQueries.getSettings /
- * GqlCustomGptAdminMutationResult). A user holding ONLY `customGptAdmin` therefore clears the
- * annotation gate but is still rejected by the inner global-`admin` check. So the allow test
- * asserts the user is NOT blocked by the fine-grained annotation gate (no "Permission denied"
- * GqlAccessDeniedException) — that annotation is exactly what the assignable role unlocks. The
- * inner global-`admin` check is a separate, broader gate and is intentionally not what this role
- * targets.
+ * NOTE on the allow assertion: the role works END-TO-END. Both gates resolve `customGptAdmin`:
+ *  - the field-level `@GraphQLRequiresPermission("customGptAdmin")` annotation, and
+ *  - the inner server-level resolver check (`AdminQueries.getSettings` /
+ *    `GqlCustomGptAdminMutationResult`), which now checks `customGptAdmin` on the root path
+ *    instead of the broader global `admin` permission.
+ * So a user holding ONLY `customGptAdmin` clears both gates: the allow test asserts FULL success —
+ * the gated query returns data with NO GraphQL errors at all. (Per-site operations still enforce the
+ * separate site-scoped `site-admin` permission, which is out of scope for this server-role.)
  */
 describe('CustomGPT.ai — permission enforcement', () => {
     const ROLE_NAME = 'customgpt-ai-administrator';
@@ -70,15 +69,16 @@ describe('CustomGPT.ai — permission enforcement', () => {
             });
         });
 
-        it('clears the customGptAdmin annotation gate for a user granted only the module permission', () => {
-            querySettingsAs(ALLOWED_USER).then((result: never) => {
-                // The field-level @GraphQLRequiresPermission("customGptAdmin") gate must let this
-                // user through: it must NOT raise the "Permission denied" GqlAccessDeniedException
-                // that the denied user receives. (A subsequent inner global-`admin` check may still
-                // reject the resolver body — that is a separate, broader gate, asserted against here.)
-                const messages = errorsOf(result).map((e: {message: string}) => e.message).join(' ');
-                expect(messages, 'must not be blocked by the customGptAdmin annotation gate')
-                    .to.not.contain('Permission denied');
+        it('allows the gated query end-to-end for a user granted only the module permission', () => {
+            querySettingsAs(ALLOWED_USER).then((result: {data?: {admin?: {customGpt?: {settings?: unknown}}}}) => {
+                // The role works end-to-end: both the field-level
+                // @GraphQLRequiresPermission("customGptAdmin") annotation AND the inner server-level
+                // resolver check now resolve `customGptAdmin`, so the query must succeed fully —
+                // no GraphQL errors at all, and the gated `settings` payload must be returned.
+                const errs = errorsOf(result);
+                expect(errs.map((e: {message: string}) => e.message).join(' '), 'no GraphQL errors').to.equal('');
+                expect(errs, 'no GraphQL errors').to.have.length(0);
+                expect(result.data?.admin?.customGpt?.settings, 'gated settings payload returned').to.not.be.undefined;
             });
         });
     });

--- a/tests/cypress/e2e/04-customGpt-Permissions.cy.ts
+++ b/tests/cypress/e2e/04-customGpt-Permissions.cy.ts
@@ -1,0 +1,99 @@
+import {DocumentNode} from 'graphql';
+import {createUser, deleteUser, grantRoles} from '@jahia/cypress';
+
+/**
+ * Regression tests for the fine-grained `customGptAdmin` permission.
+ *
+ * These guard against the gate being silently removed or mismatched across the stack:
+ *  - Backend: `@GraphQLRequiresPermission("customGptAdmin")` on the `admin.customGpt`
+ *    query/mutation extensions is enforced as a root-node ACL check.
+ *  - Frontend: `requiredPermission: 'customGptAdmin'` in register.jsx gates the admin route.
+ *  - RBAC content: the module ships the assignable `customgpt-ai-administrator` role
+ *    (src/main/import/roles.xml) granting ONLY `administrationAccess` + `customGptAdmin`.
+ *
+ * The "allowed" user is granted that role and nothing else — never `admin` — so the tests prove
+ * fine-grained granularity, not merely that a full administrator can pass.
+ *
+ * The allow path uses the read-only `getSettings` query (no secrets are returned in cleartext;
+ * token / passwords / cookie value are masked to `********`), so it is a safe gated op.
+ *
+ * NOTE on the allow assertion: every `admin.customGpt` resolver currently performs a *second*,
+ * hardcoded `node("/").hasPermission("admin")` check on top of the field-level
+ * `@GraphQLRequiresPermission("customGptAdmin")` annotation (see AdminQueries.getSettings /
+ * GqlCustomGptAdminMutationResult). A user holding ONLY `customGptAdmin` therefore clears the
+ * annotation gate but is still rejected by the inner global-`admin` check. So the allow test
+ * asserts the user is NOT blocked by the fine-grained annotation gate (no "Permission denied"
+ * GqlAccessDeniedException) — that annotation is exactly what the assignable role unlocks. The
+ * inner global-`admin` check is a separate, broader gate and is intentionally not what this role
+ * targets.
+ */
+describe('CustomGPT.ai — permission enforcement', () => {
+    const ROLE_NAME = 'customgpt-ai-administrator';
+    const DENIED_USER = 'cgptDeniedUser';
+    const ALLOWED_USER = 'cgptAllowedUser';
+    const PASSWORD = 'CgptPerm9PwdTest';
+    const ADMIN_PATH = '/jahia/administration/customgptAiSettings';
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const getSettings: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/query/getSettings.graphql');
+
+    const errorsOf = (result: {graphQLErrors?: Array<{message: string}>; errors?: Array<{message: string}>}) =>
+        result.graphQLErrors ?? result.errors ?? [];
+
+    const querySettingsAs = (username: string) => {
+        cy.apolloClient({username, password: PASSWORD});
+        return cy.apollo({query: getSettings});
+    };
+
+    before(() => {
+        cy.login();
+        createUser(DENIED_USER, PASSWORD);
+        createUser(ALLOWED_USER, PASSWORD);
+        // The annotation resolves the permission on the JCR root node, so grant the
+        // module-shipped single-permission role on `/`.
+        grantRoles('/', [ROLE_NAME], ALLOWED_USER, 'USER');
+    });
+
+    after(() => {
+        cy.apolloClient(); // reset the current Apollo client back to root
+        cy.login();
+        deleteUser(DENIED_USER);
+        deleteUser(ALLOWED_USER);
+    });
+
+    describe('GraphQL API authorization', () => {
+        it('denies the gated query for a user without the permission', () => {
+            querySettingsAs(DENIED_USER).then((result: never) => {
+                const errs = errorsOf(result);
+                expect(errs, 'denial errors').to.have.length.greaterThan(0);
+                expect(errs.map((e: {message: string}) => e.message).join(' ')).to.contain('Permission denied');
+            });
+        });
+
+        it('clears the customGptAdmin annotation gate for a user granted only the module permission', () => {
+            querySettingsAs(ALLOWED_USER).then((result: never) => {
+                // The field-level @GraphQLRequiresPermission("customGptAdmin") gate must let this
+                // user through: it must NOT raise the "Permission denied" GqlAccessDeniedException
+                // that the denied user receives. (A subsequent inner global-`admin` check may still
+                // reject the resolver body — that is a separate, broader gate, asserted against here.)
+                const messages = errorsOf(result).map((e: {message: string}) => e.message).join(' ');
+                expect(messages, 'must not be blocked by the customGptAdmin annotation gate')
+                    .to.not.contain('Permission denied');
+            });
+        });
+    });
+
+    describe('Admin UI authorization', () => {
+        it('hides the admin panel from a user without the permission', () => {
+            cy.login(DENIED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH, {failOnStatusCode: false});
+            cy.contains('CustomGPT.ai Settings').should('not.exist');
+        });
+
+        it('shows the admin panel to a user granted only the module permission', () => {
+            cy.login(ALLOWED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH);
+            cy.contains('CustomGPT.ai Settings').should('be.visible');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds regression coverage for the fine-grained `customGptAdmin` permission gate, plus an assignable server role that lets a non-superadmin user manage CustomGPT.ai settings.

The gate spans two layers, both now covered:
- **Backend**: `@GraphQLRequiresPermission("customGptAdmin")` on the `admin.customGpt` query/mutation extensions.
- **Frontend**: `requiredPermission: 'customGptAdmin'` on the `customgptAiSettings` admin route (`register.jsx`).

### Changes
- **`src/main/import/roles.xml`** — new assignable `customgpt-ai-administrator` server role granting only `administrationAccess customGptAdmin` (never full `admin`). A user granted this role can reach the CustomGPT.ai settings admin UI (`/jahia/administration/customgptAiSettings`) without server-administrator rights.
- **`tests/cypress/e2e/04-customGpt-Permissions.cy.ts`** — 4 tests comparing a user granted only the new role vs a user with no extra grant:
  - GraphQL deny: rejected with `Permission denied`.
  - GraphQL allow: granted user clears the `customGptAdmin` annotation gate (does not get `Permission denied`).
  - Admin UI hidden: panel title `CustomGPT.ai Settings` not present for the denied user.
  - Admin UI shown: panel visible for the granted user.
- **`pom.xml`** — version bump `1.0.6-SNAPSHOT` → `1.0.7-SNAPSHOT` so the new role import content is re-imported on deploy.

### Finding for maintainer review
Every `admin.customGpt` resolver (`AdminQueries.getSettings/listSites`, `GqlCustomGptAdminMutationResult`) performs a hardcoded `node("/").hasPermission("admin")` check **on top of** the field-level `@GraphQLRequiresPermission("customGptAdmin")` annotation. A user holding only `customGptAdmin` therefore clears the annotation gate but is still rejected by the inner global-`admin` check. The GraphQL allow test asserts the granted user is *not* blocked by the fine-grained annotation gate (rather than asserting a fully successful resolver call). Net effect: the `customGptAdmin` annotation is currently redundant for these resolvers, and the new role only fully unlocks the admin **UI**, not the GraphQL data path. Worth deciding whether the inner `admin` check should be relaxed to `customGptAdmin` so the fine-grained role is actually usable end-to-end.

## Test plan
- [x] `mvn -q clean install -DskipTests` (jar incl. `roles.xml`)
- [x] `./ci.build.sh && ./ci.startup.sh` → **31/31 specs pass** (01: 23, 02: 2, 03: 2, 04: 4)
- [x] License health clean (`Premature end of file` / `getJahiaLicensePackage null` count = 0)