### PR TITLE
chore: harden customgpt-ai (security, a11y AAA, quality, tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ src/main/resources/javascript/apps/.well-known/
 
 # Test artifact JARs
 tests/artifacts/*.jar
+# Jest coverage output
+coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,10 @@ This document captures the contracts, patterns, and pitfalls needed to generate 
 
 ## Project overview
 
-`customgpt-ai` is an OSGi/Jahia module (Java 11, OSGi DS, Blueprint). It:
+`customgpt-ai` is an OSGi/Jahia module (Java 11, OSGi Declarative Services). It:
 1. Integrates with the CustomGPT.ai REST API (`https://app.customgpt.ai/api/v1/`) via OkHttp3.
 2. Exposes a GraphQL API through `graphql-dxm-provider` (annotation-driven, not SDL).
-3. Provides a React 17 admin settings panel registered as a Jahia `systemComponent`.
+3. Provides a React 18 admin settings panel registered as a Jahia `systemComponent`.
 
 ---
 
@@ -21,7 +21,7 @@ This document captures the contracts, patterns, and pitfalls needed to generate 
 | Backend | Java 11, OSGi DS (`@Component`, `@Reference`), Jahia 8.2+ |
 | HTTP client | OkHttp3 4.12 (`customGptClient` with Bearer `Authenticator` + `RateLimitInterceptor`) |
 | GraphQL | `graphql-dxm-provider` 3.4 — annotation-driven (`@GraphQLField`, `@GraphQLName`, etc.) |
-| Frontend | React 17, i18next, CSS Modules (SCSS), Apollo Client |
+| Frontend | React 18, i18next, CSS Modules (SCSS), Apollo Client |
 | Testing | Cypress + TypeScript |
 
 ---

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,26 @@
+module.exports = {
+    testEnvironment: 'jsdom',
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+    // Ignore build output so Jest's haste map doesn't collide on the copied package.json.
+    modulePathIgnorePatterns: ['<rootDir>/target/', '<rootDir>/src/main/resources/javascript/apps/'],
+    moduleNameMapper: {
+        // CSS-module imports resolve to a proxy returning the key as the class name.
+        '\\.(scss|css)$': 'identity-obj-proxy'
+    },
+    transform: {
+        // Isolated Babel config (configFile/babelrc false) so Jest never inherits the
+        // webpack babel-loader pipeline or any root Babel config.
+        '^.+\\.[jt]sx?$': ['babel-jest', {
+            configFile: false,
+            babelrc: false,
+            presets: [
+                ['@babel/preset-env', {targets: {node: 'current'}}],
+                ['@babel/preset-react', {runtime: 'classic'}]
+            ]
+        }]
+    },
+    testMatch: ['**/?(*.)+(test).[jt]s?(x)'],
+    collectCoverageFrom: [
+        'src/javascript/CustomGptSettings/**/*.{js,jsx}'
+    ]
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/customgpt-ai",
-  "version": "1.0.3-SNAPSHOT",
+  "version": "1.0.7-SNAPSHOT",
   "scripts": {
     "build": "yarn webpack",
     "webpack": "webpack",
@@ -12,6 +12,8 @@
     "lint:js:fix": "yarn lint:js --fix",
     "lint": "yarn lint:js",
     "lint:fix": "yarn lint:js:fix",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
     "sync-pom": "sync-pom-version --use-yarn"
   },
   "description": "React admin UI for CustomGPT.ai settings",
@@ -39,7 +41,10 @@
     "ip-address": "^10.1.1",
     "js-yaml": "^4.1.1",
     "normalize-package-data": "^7.0.0",
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "strip-ansi": "^6.0.1",
+    "string-width": "^4.2.3",
+    "wrap-ansi": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",
@@ -49,6 +54,10 @@
     "@cyclonedx/webpack-plugin": "^5.3.2",
     "@jahia/eslint-config": "2.1.0",
     "@jahia/webpack-config": "^1.1.0",
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/react": "^14.2.0",
+    "@testing-library/user-event": "^14.5.0",
+    "babel-jest": "^29.7.0",
     "babel-loader": "^10.0.0",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^11.0.0",
@@ -58,6 +67,9 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "file-loader": "^6.2.0",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "rimraf": "^5.0.0",
     "sass": "^1.52.1",
     "sass-loader": "^12.4.0",

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,10 @@
             org.jahia.modules.graphql.provider.dxm.security;version="[2.8,4)"
         </import-package>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
+        <sonar.projectKey>org.jahia.modules.community:customgpt-ai</sonar.projectKey>
+        <sonar.sources>pom.xml,src/javascript,src/main</sonar.sources>
+        <sonar.tests>src/test</sonar.tests>
+        <sonar.exclusions>src/main/resources/javascript/apps/**,**/*.test.jsx,**/*.test.js,src/javascript/index.js,src/main/resources/resources/**</sonar.exclusions>
     </properties>
     <scm>
         <connection>scm:git:git@github.com:Jahia/customgpt-ai.git</connection>
@@ -88,6 +92,12 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.27.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.14.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/javascript/CustomGptSettings/CustomGptSettings.gql.js
+++ b/src/javascript/CustomGptSettings/CustomGptSettings.gql.js
@@ -1,7 +1,7 @@
 import {gql} from '@apollo/client';
 
 export const GET_SETTINGS = gql`
-    query {
+    query CustomGptGetSettings {
         admin {
             customGpt {
                 settings {

--- a/src/javascript/CustomGptSettings/CustomGptSettings.jsx
+++ b/src/javascript/CustomGptSettings/CustomGptSettings.jsx
@@ -108,9 +108,6 @@ export const CustomGptSettingsAdmin = () => {
             purgeDialogRef.current?.close();
             setShowPurgeDialog(false);
             setPurgeStatus({type: 'error'});
-        } finally {
-            // Return focus to the purge trigger button after dialog closes
-            document.getElementById('cgpt-purge-button')?.focus();
         }
     };
 
@@ -156,7 +153,7 @@ export const CustomGptSettingsAdmin = () => {
     const tokenDescribedBy = fieldErrors.token ? 'cgpt-token-error' : undefined;
 
     return (
-        <main className={styles.cgpt_container}>
+        <section className={styles.cgpt_container} aria-labelledby="cgpt-settings-title">
             {/* Save status live regions — always in DOM so AT registers them at mount */}
             <output
                 id="cgpt-save-status"
@@ -196,7 +193,7 @@ export const CustomGptSettingsAdmin = () => {
             </div>
 
             <div className={styles.cgpt_header}>
-                <h1>{t('label.settingsTitle')}</h1>
+                <h1 id="cgpt-settings-title">{t('label.settingsTitle')}</h1>
             </div>
 
             <div className={styles.cgpt_description}>
@@ -279,8 +276,12 @@ export const CustomGptSettingsAdmin = () => {
                             min="1"
                             max="10000"
                             value={formState.operationsBatchSize}
+                            aria-describedby="cgpt-batch-size-hint"
                             onChange={handleNumberChange('operationsBatchSize')}
                         />
+                        <span id="cgpt-batch-size-hint" className={styles.cgpt_hint}>
+                            {t('label.operationsBatchSizeHint')}
+                        </span>
                     </div>
 
                     <div className={styles.cgpt_fieldGroup}>
@@ -328,6 +329,7 @@ export const CustomGptSettingsAdmin = () => {
                         {projectName && (
                             <output
                                 id="cgpt-project-name"
+                                htmlFor="cgpt-project-id"
                                 className={styles.cgpt_projectName}
                             >
                                 {projectName}
@@ -499,7 +501,6 @@ export const CustomGptSettingsAdmin = () => {
                         label={t('label.save')}
                         variant="primary"
                         isDisabled={saving}
-                        onClick={handleSave}
                     />
                 </div>
             </form>
@@ -558,7 +559,7 @@ export const CustomGptSettingsAdmin = () => {
                     />
                 </div>
             </dialog>
-        </main>
+        </section>
     );
 };
 

--- a/src/javascript/CustomGptSettings/CustomGptSettings.jsx
+++ b/src/javascript/CustomGptSettings/CustomGptSettings.jsx
@@ -4,6 +4,14 @@ import {useTranslation} from 'react-i18next';
 import {Button, Loader, Typography} from '@jahia/moonstone';
 import styles from './CustomGptSettings.scss';
 import {GET_SETTINGS, PURGE_ALL_PAGES, SAVE_SETTINGS} from './CustomGptSettings.gql';
+import {
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_RATE_LIMIT,
+    buildSaveVariables,
+    coerceNumberInput,
+    settingsToFormState,
+    validateRequiredFields
+} from './formHelpers';
 
 export const CustomGptSettingsAdmin = () => {
     const {t} = useTranslation('customgpt-ai');
@@ -11,6 +19,10 @@ export const CustomGptSettingsAdmin = () => {
     const [purgeStatus, setPurgeStatus] = useState(null);
     const [showPurgeDialog, setShowPurgeDialog] = useState(false);
     const purgeDialogRef = useRef(null);
+    const initializedRef = useRef(false);
+
+    // Non-blocking field validation errors (guidance only — never gates the save)
+    const [fieldErrors, setFieldErrors] = useState({projectId: '', token: ''});
 
     const [projectName, setProjectName] = useState(null);
 
@@ -18,7 +30,7 @@ export const CustomGptSettingsAdmin = () => {
         contentIndexedMainResourceTypes: '',
         contentIndexedSubNodeTypes: '',
         contentIndexedFileExtensions: '',
-        operationsBatchSize: 500,
+        operationsBatchSize: DEFAULT_BATCH_SIZE,
         projectId: '',
         token: '',
         jahiaUsername: '',
@@ -29,7 +41,7 @@ export const CustomGptSettingsAdmin = () => {
         dryRun: true,
         scheduleJobASAP: false,
         apiBaseUrl: '',
-        rateLimitRequestsPerSecond: 10
+        rateLimitRequestsPerSecond: DEFAULT_RATE_LIMIT
     });
 
     useEffect(() => {
@@ -42,32 +54,23 @@ export const CustomGptSettingsAdmin = () => {
         }
     }, [showPurgeDialog]);
 
-    const {loading} = useQuery(GET_SETTINGS, {
-        fetchPolicy: 'network-only',
-        onCompleted: data => {
-            const s = data?.admin?.customGpt?.settings;
-            if (s) {
-                setProjectName(s.projectName ?? null);
-                setFormState({
-                    contentIndexedMainResourceTypes: s.contentIndexedMainResourceTypes ?? '',
-                    contentIndexedSubNodeTypes: s.contentIndexedSubNodeTypes ?? '',
-                    contentIndexedFileExtensions: s.contentIndexedFileExtensions ?? '',
-                    operationsBatchSize: s.operationsBatchSize ?? 500,
-                    projectId: s.projectId ?? '',
-                    token: s.token ?? '',
-                    jahiaUsername: s.jahiaUsername ?? '',
-                    jahiaPassword: s.jahiaPassword ?? '',
-                    jahiaServerCookieName: s.jahiaServerCookieName ?? '',
-                    jahiaServerCookieValue: s.jahiaServerCookieValue ?? '',
-                    jahiaServerCookieDomain: s.jahiaServerCookieDomain ?? '',
-                    dryRun: s.dryRun ?? true,
-                    scheduleJobASAP: s.scheduleJobASAP ?? false,
-                    apiBaseUrl: s.apiBaseUrl ?? '',
-                    rateLimitRequestsPerSecond: s.rateLimitRequestsPerSecond ?? 10
-                });
-            }
-        }
+    // One-time initialization from query data — refetches do not clobber user edits
+    const {data, loading} = useQuery(GET_SETTINGS, {
+        fetchPolicy: 'network-only'
     });
+
+    useEffect(() => {
+        if (initializedRef.current) {
+            return;
+        }
+
+        const s = data?.admin?.customGpt?.settings;
+        if (s) {
+            initializedRef.current = true;
+            setProjectName(s.projectName ?? null);
+            setFormState(settingsToFormState(s));
+        }
+    }, [data]);
 
     const [saveSettings, {loading: saving}] = useMutation(SAVE_SETTINGS);
     const [purgeAllPages, {loading: purging}] = useMutation(PURGE_ALL_PAGES);
@@ -76,11 +79,15 @@ export const CustomGptSettingsAdmin = () => {
         setSaveStatus(null);
         const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
         setFormState(prev => ({...prev, [field]: value}));
+        // Clear field error once the user provides a value
+        if ((field === 'projectId' || field === 'token') && value !== '') {
+            setFieldErrors(prev => ({...prev, [field]: ''}));
+        }
     };
 
     const handleNumberChange = field => e => {
         setSaveStatus(null);
-        const value = e.target.value === '' ? '' : parseInt(e.target.value, 10);
+        const value = coerceNumberInput(e.target.value);
         setFormState(prev => ({...prev, [field]: value}));
     };
 
@@ -89,39 +96,42 @@ export const CustomGptSettingsAdmin = () => {
     };
 
     const handlePurgeConfirm = async () => {
-        purgeDialogRef.current?.close();
-        setShowPurgeDialog(false);
+        // Keep dialog open while purging; close only after mutation settles
         try {
             const result = await purgeAllPages();
             const count = result.data?.admin?.customGpt?.purgeAllPages;
+            purgeDialogRef.current?.close();
+            setShowPurgeDialog(false);
             setPurgeStatus({type: 'success', count});
         } catch (err) {
             console.error('Failed to purge pages:', err);
+            purgeDialogRef.current?.close();
+            setShowPurgeDialog(false);
             setPurgeStatus({type: 'error'});
+        } finally {
+            // Return focus to the purge trigger button after dialog closes
+            document.getElementById('cgpt-purge-button')?.focus();
         }
     };
 
+    const handlePurgeCancel = () => {
+        purgeDialogRef.current?.close();
+    };
+
+    const handleDialogClose = () => {
+        setShowPurgeDialog(false);
+        // Return focus to the purge trigger when dialog closes via Escape or Cancel
+        document.getElementById('cgpt-purge-button')?.focus();
+    };
+
     const handleSave = async () => {
+        // Compute non-blocking guidance errors for required fields
+        const errors = validateRequiredFields(formState, t);
+        setFieldErrors(errors);
+
+        // DO NOT early-return — always proceed with the mutation regardless of errors
         try {
-            const result = await saveSettings({
-                variables: {
-                    contentIndexedMainResourceTypes: formState.contentIndexedMainResourceTypes || null,
-                    contentIndexedSubNodeTypes: formState.contentIndexedSubNodeTypes || null,
-                    contentIndexedFileExtensions: formState.contentIndexedFileExtensions || null,
-                    operationsBatchSize: formState.operationsBatchSize === '' ? null : formState.operationsBatchSize,
-                    projectId: formState.projectId || null,
-                    token: formState.token || null,
-                    jahiaUsername: formState.jahiaUsername || null,
-                    jahiaPassword: formState.jahiaPassword || null,
-                    jahiaServerCookieName: formState.jahiaServerCookieName || null,
-                    jahiaServerCookieValue: formState.jahiaServerCookieValue || null,
-                    jahiaServerCookieDomain: formState.jahiaServerCookieDomain || null,
-                    dryRun: formState.dryRun,
-                    scheduleJobASAP: formState.scheduleJobASAP,
-                    apiBaseUrl: formState.apiBaseUrl || null,
-                    rateLimitRequestsPerSecond: formState.rateLimitRequestsPerSecond === '' ? null : formState.rateLimitRequestsPerSecond
-                }
-            });
+            const result = await saveSettings({variables: buildSaveVariables(formState)});
             setSaveStatus(result.data?.admin?.customGpt?.saveSettings ? 'success' : 'error');
         } catch (err) {
             console.error('Failed to save settings:', err);
@@ -131,31 +141,62 @@ export const CustomGptSettingsAdmin = () => {
 
     if (loading) {
         return (
-            <div className={styles.cgpt_loading} role="status" aria-label={t('label.loading')}>
+            <output className={styles.cgpt_loading} aria-label={t('label.loading')}>
                 <Loader size="big" aria-hidden="true"/>
-            </div>
+            </output>
         );
     }
 
+    // Compute aria-describedby strings combining error id + projectName id where applicable
+    const projectIdDescribedBy = [
+        fieldErrors.projectId ? 'cgpt-project-id-error' : null,
+        projectName ? 'cgpt-project-name' : null
+    ].filter(Boolean).join(' ') || undefined;
+
+    const tokenDescribedBy = fieldErrors.token ? 'cgpt-token-error' : undefined;
+
     return (
-        <div className={styles.cgpt_container}>
-            {/* Save status — two fixed-role regions always in DOM so AT registers them at mount */}
-            <div role="status" aria-live="polite" aria-atomic="true" className={styles.cgpt_sr_only}>
+        <main className={styles.cgpt_container}>
+            {/* Save status live regions — always in DOM so AT registers them at mount */}
+            <output
+                id="cgpt-save-status"
+                aria-live="polite"
+                aria-atomic="true"
+                className={styles.cgpt_sr_only}
+            >
                 {saveStatus === 'success' ? t('label.saveSuccess') : ''}
-            </div>
-            <div role="alert" aria-live="assertive" aria-atomic="true" className={styles.cgpt_sr_only}>
+            </output>
+            <div
+                id="cgpt-save-error"
+                role="alert"
+                aria-live="assertive"
+                aria-atomic="true"
+                className={styles.cgpt_sr_only}
+            >
                 {saveStatus === 'error' ? t('label.saveError') : ''}
             </div>
-            {/* Purge status — two fixed-role regions always in DOM */}
-            <div role="status" aria-live="polite" aria-atomic="true" className={styles.cgpt_sr_only}>
+
+            {/* Purge status live regions — always in DOM */}
+            <output
+                id="cgpt-purge-status"
+                aria-live="polite"
+                aria-atomic="true"
+                className={styles.cgpt_sr_only}
+            >
                 {purgeStatus?.type === 'success' ? t('label.purgeSuccess', {count: purgeStatus.count}) : ''}
-            </div>
-            <div role="alert" aria-live="assertive" aria-atomic="true" className={styles.cgpt_sr_only}>
+            </output>
+            <div
+                id="cgpt-purge-error"
+                role="alert"
+                aria-live="assertive"
+                aria-atomic="true"
+                className={styles.cgpt_sr_only}
+            >
                 {purgeStatus?.type === 'error' ? t('label.purgeError') : ''}
             </div>
 
             <div className={styles.cgpt_header}>
-                <h2>{t('label.settingsTitle')}</h2>
+                <h1>{t('label.settingsTitle')}</h1>
             </div>
 
             <div className={styles.cgpt_description}>
@@ -166,257 +207,324 @@ export const CustomGptSettingsAdmin = () => {
                 <span aria-hidden="true">* </span>{t('label.requiredFieldsNote')}
             </p>
 
-            <div className={styles.cgpt_form}>
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_label} htmlFor="cgpt-main-resource-types">
-                        {t('label.contentIndexedMainResourceTypes')}
-                    </label>
-                    <input
-                        type="text"
-                        id="cgpt-main-resource-types"
-                        className={styles.cgpt_input}
-                        value={formState.contentIndexedMainResourceTypes}
-                        placeholder={t('label.contentIndexedMainResourceTypesPlaceholder')}
-                        onChange={handleChange('contentIndexedMainResourceTypes')}
-                    />
-                    <span className={styles.cgpt_hint}>{t('label.commaSeparatedHint')}</span>
+            <form
+                onSubmit={e => {
+                    e.preventDefault();
+                    handleSave();
+                }}
+            >
+                <div className={styles.cgpt_form}>
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_label} htmlFor="cgpt-main-resource-types">
+                            {t('label.contentIndexedMainResourceTypes')}
+                        </label>
+                        <input
+                            type="text"
+                            id="cgpt-main-resource-types"
+                            className={styles.cgpt_input}
+                            value={formState.contentIndexedMainResourceTypes}
+                            placeholder={t('label.contentIndexedMainResourceTypesPlaceholder')}
+                            aria-describedby="cgpt-main-resource-types-hint"
+                            onChange={handleChange('contentIndexedMainResourceTypes')}
+                        />
+                        <span id="cgpt-main-resource-types-hint" className={styles.cgpt_hint}>
+                            {t('label.commaSeparatedHint')}
+                        </span>
+                    </div>
+
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_label} htmlFor="cgpt-sub-node-types">
+                            {t('label.contentIndexedSubNodeTypes')}
+                        </label>
+                        <input
+                            type="text"
+                            id="cgpt-sub-node-types"
+                            className={styles.cgpt_input}
+                            value={formState.contentIndexedSubNodeTypes}
+                            placeholder={t('label.contentIndexedSubNodeTypesPlaceholder')}
+                            aria-describedby="cgpt-sub-node-types-hint"
+                            onChange={handleChange('contentIndexedSubNodeTypes')}
+                        />
+                        <span id="cgpt-sub-node-types-hint" className={styles.cgpt_hint}>
+                            {t('label.commaSeparatedHint')}
+                        </span>
+                    </div>
+
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_label} htmlFor="cgpt-file-extensions">
+                            {t('label.contentIndexedFileExtensions')}
+                        </label>
+                        <input
+                            type="text"
+                            id="cgpt-file-extensions"
+                            className={styles.cgpt_input}
+                            value={formState.contentIndexedFileExtensions}
+                            placeholder={t('label.contentIndexedFileExtensionsPlaceholder')}
+                            aria-describedby="cgpt-file-extensions-hint"
+                            onChange={handleChange('contentIndexedFileExtensions')}
+                        />
+                        <span id="cgpt-file-extensions-hint" className={styles.cgpt_hint}>
+                            {t('label.commaSeparatedHint')}
+                        </span>
+                    </div>
+
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_label} htmlFor="cgpt-batch-size">
+                            {t('label.operationsBatchSize')}
+                        </label>
+                        <input
+                            type="number"
+                            id="cgpt-batch-size"
+                            className={styles.cgpt_input}
+                            min="1"
+                            max="10000"
+                            value={formState.operationsBatchSize}
+                            onChange={handleNumberChange('operationsBatchSize')}
+                        />
+                    </div>
+
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_label} htmlFor="cgpt-rate-limit">
+                            {t('label.rateLimitRequestsPerSecond')}
+                        </label>
+                        <input
+                            type="number"
+                            id="cgpt-rate-limit"
+                            className={styles.cgpt_input}
+                            min="1"
+                            max="1000"
+                            value={formState.rateLimitRequestsPerSecond}
+                            aria-describedby="cgpt-rate-limit-hint"
+                            onChange={handleNumberChange('rateLimitRequestsPerSecond')}
+                        />
+                        <span id="cgpt-rate-limit-hint" className={styles.cgpt_hint}>
+                            {t('label.rateLimitRequestsPerSecondHint')}
+                        </span>
+                    </div>
+
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_label} htmlFor="cgpt-project-id">
+                            {t('label.projectId')}<span aria-hidden="true"> *</span>
+                        </label>
+                        <input
+                            type="text"
+                            id="cgpt-project-id"
+                            className={styles.cgpt_input}
+                            value={formState.projectId}
+                            aria-required="true"
+                            aria-invalid={fieldErrors.projectId ? 'true' : undefined}
+                            aria-describedby={projectIdDescribedBy || undefined}
+                            onChange={handleChange('projectId')}
+                        />
+                        {fieldErrors.projectId && (
+                            <span
+                                id="cgpt-project-id-error"
+                                role="alert"
+                                className={styles.cgpt_fieldError}
+                            >
+                                {fieldErrors.projectId}
+                            </span>
+                        )}
+                        {projectName && (
+                            <output
+                                id="cgpt-project-name"
+                                className={styles.cgpt_projectName}
+                            >
+                                {projectName}
+                            </output>
+                        )}
+                    </div>
+
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_label} htmlFor="cgpt-token">
+                            {t('label.token')}<span aria-hidden="true"> *</span>
+                        </label>
+                        <input
+                            type="password"
+                            id="cgpt-token"
+                            className={styles.cgpt_input}
+                            value={formState.token}
+                            aria-required="true"
+                            aria-invalid={fieldErrors.token ? 'true' : undefined}
+                            aria-describedby={tokenDescribedBy}
+                            onChange={handleChange('token')}
+                        />
+                        {fieldErrors.token && (
+                            <span
+                                id="cgpt-token-error"
+                                role="alert"
+                                className={styles.cgpt_fieldError}
+                            >
+                                {fieldErrors.token}
+                            </span>
+                        )}
+                    </div>
+
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_label} htmlFor="cgpt-api-base-url">
+                            {t('label.apiBaseUrl')}
+                        </label>
+                        <input
+                            type="text"
+                            id="cgpt-api-base-url"
+                            className={styles.cgpt_input}
+                            value={formState.apiBaseUrl}
+                            placeholder={t('label.apiBaseUrlPlaceholder')}
+                            autoComplete="url"
+                            onChange={handleChange('apiBaseUrl')}
+                        />
+                    </div>
+
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_label} htmlFor="cgpt-jahia-username">
+                            {t('label.jahiaUsername')}
+                        </label>
+                        <input
+                            type="text"
+                            id="cgpt-jahia-username"
+                            className={styles.cgpt_input}
+                            autoComplete="username"
+                            value={formState.jahiaUsername}
+                            onChange={handleChange('jahiaUsername')}
+                        />
+                    </div>
+
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_label} htmlFor="cgpt-jahia-password">
+                            {t('label.jahiaPassword')}
+                        </label>
+                        <input
+                            type="password"
+                            id="cgpt-jahia-password"
+                            className={styles.cgpt_input}
+                            autoComplete="current-password"
+                            value={formState.jahiaPassword}
+                            onChange={handleChange('jahiaPassword')}
+                        />
+                    </div>
+
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_label} htmlFor="cgpt-cookie-name">
+                            {t('label.jahiaServerCookieName')}
+                        </label>
+                        <input
+                            type="text"
+                            id="cgpt-cookie-name"
+                            className={styles.cgpt_input}
+                            value={formState.jahiaServerCookieName}
+                            onChange={handleChange('jahiaServerCookieName')}
+                        />
+                    </div>
+
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_label} htmlFor="cgpt-cookie-value">
+                            {t('label.jahiaServerCookieValue')}
+                        </label>
+                        <input
+                            type="text"
+                            id="cgpt-cookie-value"
+                            className={styles.cgpt_input}
+                            value={formState.jahiaServerCookieValue}
+                            onChange={handleChange('jahiaServerCookieValue')}
+                        />
+                    </div>
+
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_label} htmlFor="cgpt-cookie-domain">
+                            {t('label.jahiaServerCookieDomain')}
+                        </label>
+                        <input
+                            type="text"
+                            id="cgpt-cookie-domain"
+                            className={styles.cgpt_input}
+                            value={formState.jahiaServerCookieDomain}
+                            onChange={handleChange('jahiaServerCookieDomain')}
+                        />
+                    </div>
+
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_checkboxLabel} htmlFor="cgpt-dry-run">
+                            <input
+                                type="checkbox"
+                                id="cgpt-dry-run"
+                                className={styles.cgpt_checkbox}
+                                checked={formState.dryRun}
+                                aria-describedby="cgpt-dry-run-hint"
+                                onChange={handleChange('dryRun')}
+                            />
+                            {t('label.dryRun')}
+                        </label>
+                        <span id="cgpt-dry-run-hint" className={styles.cgpt_hint}>
+                            {t('label.dryRunHint')}
+                        </span>
+                    </div>
+
+                    <div className={styles.cgpt_fieldGroup}>
+                        <label className={styles.cgpt_checkboxLabel} htmlFor="cgpt-schedule-asap">
+                            <input
+                                type="checkbox"
+                                id="cgpt-schedule-asap"
+                                className={styles.cgpt_checkbox}
+                                checked={formState.scheduleJobASAP}
+                                aria-describedby="cgpt-schedule-asap-hint"
+                                onChange={handleChange('scheduleJobASAP')}
+                            />
+                            {t('label.scheduleJobASAP')}
+                        </label>
+                        <span id="cgpt-schedule-asap-hint" className={styles.cgpt_hint}>
+                            {t('label.scheduleJobASAPHint')}
+                        </span>
+                    </div>
                 </div>
 
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_label} htmlFor="cgpt-sub-node-types">
-                        {t('label.contentIndexedSubNodeTypes')}
-                    </label>
-                    <input
-                        type="text"
-                        id="cgpt-sub-node-types"
-                        className={styles.cgpt_input}
-                        value={formState.contentIndexedSubNodeTypes}
-                        placeholder={t('label.contentIndexedSubNodeTypesPlaceholder')}
-                        onChange={handleChange('contentIndexedSubNodeTypes')}
-                    />
-                    <span className={styles.cgpt_hint}>{t('label.commaSeparatedHint')}</span>
-                </div>
-
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_label} htmlFor="cgpt-file-extensions">
-                        {t('label.contentIndexedFileExtensions')}
-                    </label>
-                    <input
-                        type="text"
-                        id="cgpt-file-extensions"
-                        className={styles.cgpt_input}
-                        value={formState.contentIndexedFileExtensions}
-                        placeholder={t('label.contentIndexedFileExtensionsPlaceholder')}
-                        onChange={handleChange('contentIndexedFileExtensions')}
-                    />
-                    <span className={styles.cgpt_hint}>{t('label.commaSeparatedHint')}</span>
-                </div>
-
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_label} htmlFor="cgpt-batch-size">
-                        {t('label.operationsBatchSize')}
-                    </label>
-                    <input
-                        type="number"
-                        id="cgpt-batch-size"
-                        className={styles.cgpt_input}
-                        value={formState.operationsBatchSize}
-                        onChange={handleNumberChange('operationsBatchSize')}
-                    />
-                </div>
-
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_label} htmlFor="cgpt-rate-limit">
-                        {t('label.rateLimitRequestsPerSecond')}
-                    </label>
-                    <input
-                        type="number"
-                        id="cgpt-rate-limit"
-                        className={styles.cgpt_input}
-                        min="1"
-                        value={formState.rateLimitRequestsPerSecond}
-                        onChange={handleNumberChange('rateLimitRequestsPerSecond')}
-                    />
-                    <span className={styles.cgpt_hint}>{t('label.rateLimitRequestsPerSecondHint')}</span>
-                </div>
-
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_label} htmlFor="cgpt-project-id">
-                        {t('label.projectId')}<span aria-hidden="true"> *</span>
-                    </label>
-                    <input
-                        type="text"
-                        id="cgpt-project-id"
-                        className={styles.cgpt_input}
-                        value={formState.projectId}
-                        required
-                        aria-required="true"
-                        onChange={handleChange('projectId')}
-                    />
-                    {projectName && (
-                        <span className={styles.cgpt_projectName}>{projectName}</span>
+                <div className={styles.cgpt_actions}>
+                    {saveStatus === 'success' && (
+                        <div
+                            aria-hidden="true"
+                            className={`${styles.cgpt_alert} ${styles['cgpt_alert--success']}`}
+                        >
+                            {t('label.saveSuccess')}
+                        </div>
                     )}
-                </div>
-
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_label} htmlFor="cgpt-token">
-                        {t('label.token')}<span aria-hidden="true"> *</span>
-                    </label>
-                    <input
-                        type="password"
-                        id="cgpt-token"
-                        className={styles.cgpt_input}
-                        value={formState.token}
-                        required
-                        aria-required="true"
-                        onChange={handleChange('token')}
+                    {saveStatus === 'error' && (
+                        <div
+                            aria-hidden="true"
+                            className={`${styles.cgpt_alert} ${styles['cgpt_alert--error']}`}
+                        >
+                            {t('label.saveError')}
+                        </div>
+                    )}
+                    <Button
+                        type="submit"
+                        label={t('label.save')}
+                        variant="primary"
+                        isDisabled={saving}
+                        onClick={handleSave}
                     />
                 </div>
-
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_label} htmlFor="cgpt-api-base-url">
-                        {t('label.apiBaseUrl')}
-                    </label>
-                    <input
-                        type="text"
-                        id="cgpt-api-base-url"
-                        className={styles.cgpt_input}
-                        value={formState.apiBaseUrl}
-                        placeholder={t('label.apiBaseUrlPlaceholder')}
-                        onChange={handleChange('apiBaseUrl')}
-                    />
-                </div>
-
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_label} htmlFor="cgpt-jahia-username">
-                        {t('label.jahiaUsername')}
-                    </label>
-                    <input
-                        type="text"
-                        id="cgpt-jahia-username"
-                        className={styles.cgpt_input}
-                        autoComplete="username"
-                        value={formState.jahiaUsername}
-                        onChange={handleChange('jahiaUsername')}
-                    />
-                </div>
-
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_label} htmlFor="cgpt-jahia-password">
-                        {t('label.jahiaPassword')}
-                    </label>
-                    <input
-                        type="password"
-                        id="cgpt-jahia-password"
-                        className={styles.cgpt_input}
-                        autoComplete="current-password"
-                        value={formState.jahiaPassword}
-                        onChange={handleChange('jahiaPassword')}
-                    />
-                </div>
-
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_label} htmlFor="cgpt-cookie-name">
-                        {t('label.jahiaServerCookieName')}
-                    </label>
-                    <input
-                        type="text"
-                        id="cgpt-cookie-name"
-                        className={styles.cgpt_input}
-                        value={formState.jahiaServerCookieName}
-                        onChange={handleChange('jahiaServerCookieName')}
-                    />
-                </div>
-
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_label} htmlFor="cgpt-cookie-value">
-                        {t('label.jahiaServerCookieValue')}
-                    </label>
-                    <input
-                        type="text"
-                        id="cgpt-cookie-value"
-                        className={styles.cgpt_input}
-                        value={formState.jahiaServerCookieValue}
-                        onChange={handleChange('jahiaServerCookieValue')}
-                    />
-                </div>
-
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_label} htmlFor="cgpt-cookie-domain">
-                        {t('label.jahiaServerCookieDomain')}
-                    </label>
-                    <input
-                        type="text"
-                        id="cgpt-cookie-domain"
-                        className={styles.cgpt_input}
-                        value={formState.jahiaServerCookieDomain}
-                        onChange={handleChange('jahiaServerCookieDomain')}
-                    />
-                </div>
-
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_checkboxLabel} htmlFor="cgpt-dry-run">
-                        <input
-                            type="checkbox"
-                            id="cgpt-dry-run"
-                            className={styles.cgpt_checkbox}
-                            checked={formState.dryRun}
-                            onChange={handleChange('dryRun')}
-                        />
-                        {t('label.dryRun')}
-                    </label>
-                    <span className={styles.cgpt_hint}>{t('label.dryRunHint')}</span>
-                </div>
-
-                <div className={styles.cgpt_fieldGroup}>
-                    <label className={styles.cgpt_checkboxLabel} htmlFor="cgpt-schedule-asap">
-                        <input
-                            type="checkbox"
-                            id="cgpt-schedule-asap"
-                            className={styles.cgpt_checkbox}
-                            checked={formState.scheduleJobASAP}
-                            onChange={handleChange('scheduleJobASAP')}
-                        />
-                        {t('label.scheduleJobASAP')}
-                    </label>
-                    <span className={styles.cgpt_hint}>{t('label.scheduleJobASAPHint')}</span>
-                </div>
-            </div>
-
-            <div className={styles.cgpt_actions}>
-                {saveStatus === 'success' && (
-                    <div aria-hidden="true" className={`${styles.cgpt_alert} ${styles['cgpt_alert--success']}`}>
-                        {t('label.saveSuccess')}
-                    </div>
-                )}
-                {saveStatus === 'error' && (
-                    <div aria-hidden="true" className={`${styles.cgpt_alert} ${styles['cgpt_alert--error']}`}>
-                        {t('label.saveError')}
-                    </div>
-                )}
-                <Button
-                    type="button"
-                    label={t('label.save')}
-                    variant="primary"
-                    isDisabled={saving}
-                    onClick={handleSave}
-                />
-            </div>
+            </form>
 
             <div className={styles.cgpt_dangerZone}>
-                <h3>{t('label.dangerZoneTitle')}</h3>
+                <h2>{t('label.dangerZoneTitle')}</h2>
                 {purgeStatus?.type === 'success' && (
-                    <div aria-hidden="true" className={`${styles.cgpt_alert} ${styles['cgpt_alert--success']}`}>
+                    <div
+                        aria-hidden="true"
+                        className={`${styles.cgpt_alert} ${styles['cgpt_alert--success']}`}
+                    >
                         {t('label.purgeSuccess', {count: purgeStatus.count})}
                     </div>
                 )}
                 {purgeStatus?.type === 'error' && (
-                    <div aria-hidden="true" className={`${styles.cgpt_alert} ${styles['cgpt_alert--error']}`}>
+                    <div
+                        aria-hidden="true"
+                        className={`${styles.cgpt_alert} ${styles['cgpt_alert--error']}`}
+                    >
                         {t('label.purgeError')}
                     </div>
                 )}
                 <Button
                     type="button"
+                    id="cgpt-purge-button"
                     label={t('label.purgeAllPages')}
                     variant="danger"
                     isDisabled={purging}
@@ -430,24 +538,27 @@ export const CustomGptSettingsAdmin = () => {
                 aria-labelledby="cgpt-purge-dialog-title"
                 aria-describedby="cgpt-purge-dialog-desc"
                 className={styles.cgpt_dialog}
-                onClose={() => setShowPurgeDialog(false)}
+                onClose={handleDialogClose}
             >
-                <h3 id="cgpt-purge-dialog-title">{t('label.purgeConfirmTitle')}</h3>
+                <h2 id="cgpt-purge-dialog-title">{t('label.purgeConfirmTitle')}</h2>
                 <p id="cgpt-purge-dialog-desc">{t('label.purgeConfirm')}</p>
                 <div className={styles.cgpt_dialogActions}>
                     <Button
+                        type="button"
                         label={t('label.cancel')}
-                        onClick={() => purgeDialogRef.current?.close()}
+                        isDisabled={purging}
+                        onClick={handlePurgeCancel}
                     />
                     <Button
-                        label={t('label.confirmPurge')}
+                        type="button"
+                        label={purging ? t('label.purging') : t('label.confirmPurge')}
                         variant="danger"
                         isDisabled={purging}
                         onClick={handlePurgeConfirm}
                     />
                 </div>
             </dialog>
-        </div>
+        </main>
     );
 };
 

--- a/src/javascript/CustomGptSettings/CustomGptSettings.scss
+++ b/src/javascript/CustomGptSettings/CustomGptSettings.scss
@@ -17,6 +17,14 @@
     padding: 48px;
 }
 
+// Disable spinner animation for users who prefer reduced motion
+@media (prefers-reduced-motion: reduce) {
+    .cgpt_loading * {
+        animation: none !important;
+        transition: none !important;
+    }
+}
+
 .cgpt_container {
     padding: 24px 32px;
     width: 100%;
@@ -28,7 +36,7 @@
 .cgpt_header {
     margin-bottom: 8px;
 
-    h2 {
+    h1 {
         font-size: 1.25rem;
         font-weight: 600;
         margin: 0;
@@ -37,11 +45,13 @@
 
 .cgpt_description {
     margin-bottom: 16px;
+    // #545454 on white = ~7.4:1 — AAA OK
     color: #545454;
 }
 
 .cgpt_requiredNote {
     font-size: 0.875rem;
+    // #333 on white > 10:1 — AAA OK
     color: #333;
     margin: 0 0 16px;
 }
@@ -62,6 +72,7 @@
 .cgpt_label {
     font-size: 0.875rem;
     font-weight: 500;
+    // #333 on white > 10:1 — AAA OK
     color: #333;
 }
 
@@ -71,14 +82,21 @@
     gap: 8px;
     font-size: 0.875rem;
     font-weight: 500;
+    // #333 on white > 10:1 — AAA OK
     color: #333;
     cursor: pointer;
 }
 
 .cgpt_checkbox {
-    width: 16px;
-    height: 16px;
+    // AAA target size: minimum 24×24 px (SC 2.5.8)
+    width: 24px;
+    height: 24px;
     cursor: pointer;
+
+    &:focus-visible {
+        outline: 2px solid #0077cc;
+        outline-offset: 2px;
+    }
 }
 
 .cgpt_input {
@@ -98,8 +116,17 @@
 
 .cgpt_hint {
     font-size: 0.75rem;
-    color: #595959;
+    // #525252 on white ~ 7.0:1 — AAA OK (was #595959 ~5.9:1 which was AA only)
+    color: #525252;
     font-style: italic;
+}
+
+// Inline field-level validation guidance (non-blocking — save still proceeds)
+.cgpt_fieldError {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    // #7f0000 on white ~ 9.6:1 — AAA OK
+    color: #7f0000;
 }
 
 .cgpt_actions {
@@ -111,24 +138,30 @@
 
 .cgpt_projectName {
     font-size: 0.8125rem;
-    color: #006633;
+    // #004d29 on white ~ 9.0:1 — AAA OK (was #006633 ~5.9:1 which was AA only)
+    color: #004d29;
     font-style: italic;
     margin-top: 4px;
 }
 
 .cgpt_dangerZone {
-    margin-top: 32px;
-    padding: 16px;
-    border: 1px solid #c62828;
+    // Stronger visual separation: tinted background + thicker left accent border
+    margin-top: 48px;
+    padding: 20px 20px 20px 24px;
+    // Light red tint — #fff5f5 on white, border provides the colour boundary
+    background-color: #fff5f5;
+    border: 1px solid #7f0000;
+    border-left: 4px solid #7f0000;
     border-radius: 4px;
     display: flex;
     flex-direction: column;
     gap: 12px;
     align-items: flex-start;
 
-    h3 {
+    h2 {
         margin: 0 0 4px;
-        color: #c62828;
+        // #7f0000 on #fff5f5 ~ 9.1:1 — AAA OK (was #c62828 ~4.9:1, AA only)
+        color: #7f0000;
         font-size: 1rem;
     }
 }
@@ -143,13 +176,15 @@
     &--success {
         background-color: #e8f5e9;
         border: 1px solid #388e3c;
+        // #1b5e20 on #e8f5e9 ~ 7.8:1 — AAA OK
         color: #1b5e20;
     }
 
     &--error {
         background-color: #fdecea;
-        border: 1px solid #c62828;
-        color: #c62828;
+        border: 1px solid #7f0000;
+        // #7f0000 on #fdecea ~ 9.1:1 — AAA OK (was #c62828 ~4.9:1, AA only)
+        color: #7f0000;
     }
 }
 
@@ -160,11 +195,12 @@
     max-width: 480px;
     width: 90vw;
 
-    h3 {
+    h2 {
         margin: 0 0 12px;
         font-size: 1rem;
         font-weight: 600;
-        color: #c62828;
+        // #7f0000 on white ~ 9.6:1 — AAA OK (was #c62828 ~4.9:1, AA only)
+        color: #7f0000;
     }
 
     p {

--- a/src/javascript/CustomGptSettings/CustomGptSettings.test.jsx
+++ b/src/javascript/CustomGptSettings/CustomGptSettings.test.jsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import CustomGptSettingsAdmin from './CustomGptSettings';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+// Translate by echoing the key so assertions stay independent of locale copy.
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({t: key => key})
+}));
+
+jest.mock('@jahia/moonstone', () => {
+    const React = require('react');
+    return {
+        // Forward id/onClick/disabled so role/label queries and focus work. Type is fixed
+        // to "button" so clicks fire onClick without an implicit form submit double-firing.
+        Button: ({label, id, isDisabled, onClick}) =>
+            React.createElement('button', {id, type: 'button', disabled: isDisabled, onClick}, label),
+        Loader: () => React.createElement('div', {'data-testid': 'loader'}),
+        Typography: ({children}) => React.createElement('div', null, children)
+    };
+});
+
+// Apollo hooks are mocked per-test via these controllable refs.
+let mockUseQueryReturn;
+let mockSaveSettings;
+let mockPurgeAllPages;
+
+jest.mock('@apollo/client', () => ({
+    gql: () => ({}),
+    useQuery: () => mockUseQueryReturn,
+    useMutation: fn => {
+        // Identify which mutation by the document; the component passes SAVE_SETTINGS first.
+        if (fn === 'SAVE_SETTINGS') {
+            return [mockSaveSettings, {loading: false}];
+        }
+
+        return [mockPurgeAllPages, {loading: false}];
+    }
+}));
+
+// Make the gql document objects identifiable strings for the useMutation mock above.
+jest.mock('./CustomGptSettings.gql', () => ({
+    GET_SETTINGS: 'GET_SETTINGS',
+    SAVE_SETTINGS: 'SAVE_SETTINGS',
+    PURGE_ALL_PAGES: 'PURGE_ALL_PAGES'
+}));
+
+// Jsdom does not implement <dialog>.showModal / close — polyfill before importing component.
+beforeAll(() => {
+    HTMLDialogElement.prototype.showModal = function () {
+        this.open = true;
+    };
+
+    HTMLDialogElement.prototype.close = function () {
+        this.open = false;
+        this.dispatchEvent(new Event('close'));
+    };
+});
+
+const fullSettings = {
+    contentIndexedMainResourceTypes: 'jnt:page',
+    contentIndexedSubNodeTypes: 'jnt:text',
+    contentIndexedFileExtensions: 'pdf',
+    operationsBatchSize: 250,
+    projectId: 'proj-123',
+    projectName: 'My Project',
+    token: 'secret-token',
+    jahiaUsername: 'root',
+    jahiaPassword: 'pw',
+    jahiaServerCookieName: '',
+    jahiaServerCookieValue: '',
+    jahiaServerCookieDomain: '',
+    dryRun: false,
+    scheduleJobASAP: true,
+    apiBaseUrl: 'https://api.example.com',
+    rateLimitRequestsPerSecond: 5
+};
+
+const settingsData = settings => ({admin: {customGpt: {settings}}});
+
+beforeEach(() => {
+    mockSaveSettings = jest.fn().mockResolvedValue({data: {admin: {customGpt: {saveSettings: true}}}});
+    mockPurgeAllPages = jest.fn().mockResolvedValue({data: {admin: {customGpt: {purgeAllPages: 3}}}});
+    mockUseQueryReturn = {data: undefined, loading: false};
+});
+
+describe('CustomGptSettingsAdmin', () => {
+    test('renders the loading state while the query is in flight', () => {
+        mockUseQueryReturn = {data: undefined, loading: true};
+        render(<CustomGptSettingsAdmin/>);
+        expect(screen.getByRole('status', {name: 'label.loading'})).toBeInTheDocument();
+        expect(screen.getByTestId('loader')).toBeInTheDocument();
+    });
+
+    test('renders the form populated with the fetched settings', () => {
+        mockUseQueryReturn = {data: settingsData(fullSettings), loading: false};
+        render(<CustomGptSettingsAdmin/>);
+        expect(screen.getByLabelText('label.contentIndexedMainResourceTypes')).toHaveValue('jnt:page');
+        // Required-field labels carry a trailing " *" marker, so match by prefix.
+        expect(screen.getByLabelText(/^label\.projectId/)).toHaveValue('proj-123');
+        expect(screen.getByLabelText(/^label\.token/)).toHaveValue('secret-token');
+        // ProjectName is rendered as guidance next to the projectId field.
+        expect(screen.getByText('My Project')).toBeInTheDocument();
+    });
+
+    test('shows an inline aria error and sets aria-invalid when a required field is empty on save', async () => {
+        mockUseQueryReturn = {
+            data: settingsData({...fullSettings, projectId: '', token: ''}),
+            loading: false
+        };
+        render(<CustomGptSettingsAdmin/>);
+
+        const projectId = screen.getByLabelText(/^label\.projectId/);
+        const token = screen.getByLabelText(/^label\.token/);
+        expect(projectId).not.toHaveAttribute('aria-invalid', 'true');
+
+        fireEvent.click(screen.getByRole('button', {name: 'label.save'}));
+
+        await waitFor(() => {
+            expect(projectId).toHaveAttribute('aria-invalid', 'true');
+        });
+        expect(token).toHaveAttribute('aria-invalid', 'true');
+        // Inline alerts surface the validation copy.
+        const alerts = screen.getAllByRole('alert');
+        const messages = alerts.map(a => a.textContent);
+        expect(messages).toContain('label.validationProjectIdRequired');
+        expect(messages).toContain('label.validationTokenRequired');
+
+        // Non-blocking: the save mutation still fires regardless of validation errors.
+        await waitFor(() => expect(mockSaveSettings).toHaveBeenCalled());
+    });
+
+    test('opens the purge dialog and returns focus to the trigger on cancel', async () => {
+        mockUseQueryReturn = {data: settingsData(fullSettings), loading: false};
+        render(<CustomGptSettingsAdmin/>);
+
+        const trigger = document.getElementById('cgpt-purge-button');
+        expect(trigger).toBeInTheDocument();
+
+        fireEvent.click(trigger);
+
+        const dialog = screen.getByRole('alertdialog');
+        await waitFor(() => expect(dialog.open).toBe(true));
+
+        fireEvent.click(screen.getByRole('button', {name: 'label.cancel'}));
+
+        // Cancel closes the dialog, which fires onClose → focus returns to the trigger.
+        await waitFor(() => expect(dialog.open).toBe(false));
+        await waitFor(() => expect(document.activeElement).toBe(trigger));
+        // No purge mutation should have been issued on cancel.
+        expect(mockPurgeAllPages).not.toHaveBeenCalled();
+    });
+});

--- a/src/javascript/CustomGptSettings/CustomGptSettings.test.jsx
+++ b/src/javascript/CustomGptSettings/CustomGptSettings.test.jsx
@@ -11,10 +11,11 @@ jest.mock('react-i18next', () => ({
 jest.mock('@jahia/moonstone', () => {
     const React = require('react');
     return {
-        // Forward id/onClick/disabled so role/label queries and focus work. Type is fixed
-        // to "button" so clicks fire onClick without an implicit form submit double-firing.
-        Button: ({label, id, isDisabled, onClick}) =>
-            React.createElement('button', {id, type: 'button', disabled: isDisabled, onClick}, label),
+        // Forward id/type/onClick/disabled so role/label queries, focus, and native form
+        // submission work. The Save button is type="submit" and relies solely on the form's
+        // onSubmit (no onClick) — clicking it submits the form once via jsdom.
+        Button: ({label, id, type, isDisabled, onClick}) =>
+            React.createElement('button', {id, type: type === 'submit' ? 'submit' : 'button', disabled: isDisabled, onClick}, label),
         Loader: () => React.createElement('div', {'data-testid': 'loader'}),
         Typography: ({children}) => React.createElement('div', null, children)
     };

--- a/src/javascript/CustomGptSettings/formHelpers.js
+++ b/src/javascript/CustomGptSettings/formHelpers.js
@@ -1,0 +1,65 @@
+// Pure, framework-free helpers extracted from CustomGptSettings.jsx for unit testing.
+// No behavioral changes — these are the exact transforms that were previously inline.
+
+export const DEFAULT_BATCH_SIZE = 500;
+export const DEFAULT_RATE_LIMIT = 10;
+
+// Maps server settings to the form state, applying defaults for missing values.
+export const settingsToFormState = s => ({
+    contentIndexedMainResourceTypes: s.contentIndexedMainResourceTypes ?? '',
+    contentIndexedSubNodeTypes: s.contentIndexedSubNodeTypes ?? '',
+    contentIndexedFileExtensions: s.contentIndexedFileExtensions ?? '',
+    operationsBatchSize: s.operationsBatchSize ?? DEFAULT_BATCH_SIZE,
+    projectId: s.projectId ?? '',
+    token: s.token ?? '',
+    jahiaUsername: s.jahiaUsername ?? '',
+    jahiaPassword: s.jahiaPassword ?? '',
+    jahiaServerCookieName: s.jahiaServerCookieName ?? '',
+    jahiaServerCookieValue: s.jahiaServerCookieValue ?? '',
+    jahiaServerCookieDomain: s.jahiaServerCookieDomain ?? '',
+    dryRun: s.dryRun ?? true,
+    scheduleJobASAP: s.scheduleJobASAP ?? false,
+    apiBaseUrl: s.apiBaseUrl ?? '',
+    rateLimitRequestsPerSecond: s.rateLimitRequestsPerSecond ?? DEFAULT_RATE_LIMIT
+});
+
+// Maps the form state to saveSettings mutation variables; empty strings become null.
+export const buildSaveVariables = formState => {
+    const text = value => value || null;
+    const number = value => (value === '' ? null : value);
+    return {
+        contentIndexedMainResourceTypes: text(formState.contentIndexedMainResourceTypes),
+        contentIndexedSubNodeTypes: text(formState.contentIndexedSubNodeTypes),
+        contentIndexedFileExtensions: text(formState.contentIndexedFileExtensions),
+        operationsBatchSize: number(formState.operationsBatchSize),
+        projectId: text(formState.projectId),
+        token: text(formState.token),
+        jahiaUsername: text(formState.jahiaUsername),
+        jahiaPassword: text(formState.jahiaPassword),
+        jahiaServerCookieName: text(formState.jahiaServerCookieName),
+        jahiaServerCookieValue: text(formState.jahiaServerCookieValue),
+        jahiaServerCookieDomain: text(formState.jahiaServerCookieDomain),
+        dryRun: formState.dryRun,
+        scheduleJobASAP: formState.scheduleJobASAP,
+        apiBaseUrl: text(formState.apiBaseUrl),
+        rateLimitRequestsPerSecond: number(formState.rateLimitRequestsPerSecond)
+    };
+};
+
+// Coerces a raw number-input string to an int, or '' when empty / NaN.
+// Mirrors the previous inline logic in handleNumberChange — identical behavior.
+export const coerceNumberInput = raw => {
+    if (raw === '') {
+        return '';
+    }
+
+    const n = Number.parseInt(raw, 10);
+    return Number.isNaN(n) ? '' : n;
+};
+
+// Computes the non-blocking required-field guidance errors.
+// `t` is the i18next translator; returns '' for a satisfied field.
+export const validateRequiredFields = (formState, t) => ({
+    projectId: formState.projectId === '' ? t('label.validationProjectIdRequired') : '',
+    token: formState.token === '' ? t('label.validationTokenRequired') : ''
+});

--- a/src/javascript/CustomGptSettings/formHelpers.test.js
+++ b/src/javascript/CustomGptSettings/formHelpers.test.js
@@ -1,0 +1,123 @@
+import {
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_RATE_LIMIT,
+    buildSaveVariables,
+    coerceNumberInput,
+    settingsToFormState,
+    validateRequiredFields
+} from './formHelpers';
+
+describe('coerceNumberInput', () => {
+    test('returns the parsed integer for a valid numeric string', () => {
+        expect(coerceNumberInput('250')).toBe(250);
+    });
+
+    test('returns empty string for an empty input (fallback)', () => {
+        expect(coerceNumberInput('')).toBe('');
+    });
+
+    test('returns empty string for a non-numeric / NaN input (fallback)', () => {
+        expect(coerceNumberInput('abc')).toBe('');
+    });
+
+    test('parses leading-numeric values the way parseInt does', () => {
+        expect(coerceNumberInput('42px')).toBe(42);
+    });
+});
+
+describe('buildSaveVariables — empty strings become null', () => {
+    test('coerces empty text fields to null and keeps populated ones', () => {
+        const vars = buildSaveVariables({
+            contentIndexedMainResourceTypes: '',
+            contentIndexedSubNodeTypes: 'jnt:text',
+            contentIndexedFileExtensions: '',
+            operationsBatchSize: 500,
+            projectId: '',
+            token: 'secret',
+            jahiaUsername: '',
+            jahiaPassword: '',
+            jahiaServerCookieName: '',
+            jahiaServerCookieValue: '',
+            jahiaServerCookieDomain: '',
+            dryRun: true,
+            scheduleJobASAP: false,
+            apiBaseUrl: '',
+            rateLimitRequestsPerSecond: 10
+        });
+
+        expect(vars.contentIndexedMainResourceTypes).toBeNull();
+        expect(vars.contentIndexedSubNodeTypes).toBe('jnt:text');
+        expect(vars.projectId).toBeNull();
+        expect(vars.token).toBe('secret');
+        expect(vars.apiBaseUrl).toBeNull();
+    });
+
+    test('coerces empty-string numeric fields to null but keeps numeric values (including 0-safe path)', () => {
+        const vars = buildSaveVariables({
+            operationsBatchSize: '',
+            rateLimitRequestsPerSecond: 10,
+            dryRun: false,
+            scheduleJobASAP: true
+        });
+
+        expect(vars.operationsBatchSize).toBeNull();
+        expect(vars.rateLimitRequestsPerSecond).toBe(10);
+    });
+
+    test('passes boolean flags through unchanged', () => {
+        const vars = buildSaveVariables({dryRun: false, scheduleJobASAP: true});
+        expect(vars.dryRun).toBe(false);
+        expect(vars.scheduleJobASAP).toBe(true);
+    });
+});
+
+describe('settingsToFormState — settings to form mapping', () => {
+    test('applies defaults for missing values', () => {
+        const formState = settingsToFormState({});
+        expect(formState.contentIndexedMainResourceTypes).toBe('');
+        expect(formState.operationsBatchSize).toBe(DEFAULT_BATCH_SIZE);
+        expect(formState.rateLimitRequestsPerSecond).toBe(DEFAULT_RATE_LIMIT);
+        expect(formState.dryRun).toBe(true);
+        expect(formState.scheduleJobASAP).toBe(false);
+        expect(formState.projectId).toBe('');
+    });
+
+    test('preserves provided values, including falsy dryRun=false', () => {
+        const formState = settingsToFormState({
+            projectId: 'proj-123',
+            token: 'tok',
+            operationsBatchSize: 250,
+            dryRun: false,
+            scheduleJobASAP: true,
+            apiBaseUrl: 'https://api.example.com'
+        });
+        expect(formState.projectId).toBe('proj-123');
+        expect(formState.token).toBe('tok');
+        expect(formState.operationsBatchSize).toBe(250);
+        expect(formState.dryRun).toBe(false);
+        expect(formState.scheduleJobASAP).toBe(true);
+        expect(formState.apiBaseUrl).toBe('https://api.example.com');
+    });
+});
+
+describe('validateRequiredFields', () => {
+    const t = key => key;
+
+    test('reports both required errors when projectId and token are empty', () => {
+        const errors = validateRequiredFields({projectId: '', token: ''}, t);
+        expect(errors.projectId).toBe('label.validationProjectIdRequired');
+        expect(errors.token).toBe('label.validationTokenRequired');
+    });
+
+    test('reports no errors when both required fields are present', () => {
+        const errors = validateRequiredFields({projectId: 'p', token: 't'}, t);
+        expect(errors.projectId).toBe('');
+        expect(errors.token).toBe('');
+    });
+
+    test('reports only the empty field', () => {
+        const errors = validateRequiredFields({projectId: 'p', token: ''}, t);
+        expect(errors.projectId).toBe('');
+        expect(errors.token).toBe('label.validationTokenRequired');
+    });
+});

--- a/src/javascript/CustomGptSettings/register.jsx
+++ b/src/javascript/CustomGptSettings/register.jsx
@@ -2,8 +2,7 @@ import {registry} from '@jahia/ui-extender';
 import {CustomGptSettingsAdmin} from './CustomGptSettings';
 import React from 'react';
 
-export default () => {
-    console.debug('%c customgpt-ai: activation in progress', 'color: #006633');
+export default function registerAdminRoute() {
     registry.add('adminRoute', 'customgptAiSettings', {
         targets: ['administration-server-configuration:25'],
         requiredPermission: 'customGptAdmin',
@@ -11,4 +10,4 @@ export default () => {
         isSelectable: true,
         render: () => React.createElement(CustomGptSettingsAdmin)
     });
-};
+}

--- a/src/javascript/index.js
+++ b/src/javascript/index.js
@@ -1,5 +1,4 @@
 import('@jahia/app-shell/bootstrap').then(res => {
-    console.log(res);
     window.jahia = res;
     res.startAppShell(window.appShell.remotes, window.appShell.targetId);
 });

--- a/src/javascript/init.js
+++ b/src/javascript/init.js
@@ -2,15 +2,12 @@ import {registry} from '@jahia/ui-extender';
 import register from './CustomGptSettings/register';
 import i18next from 'i18next';
 
-export default function () {
+export default function initCustomGpt() {
     registry.add('callback', 'customgpt-ai', {
         targets: ['jahiaApp-init:50'],
         callback: async () => {
-            await i18next.loadNamespaces('customgpt-ai', () => {
-                console.debug('%c customgpt-ai: i18n namespace loaded', 'color: #006633');
-            });
+            await i18next.loadNamespaces('customgpt-ai');
             register();
-            console.debug('%c customgpt-ai: activation completed', 'color: #006633');
         }
     });
 }

--- a/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/models/GqlCustomGptAdminMutationResult.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/models/GqlCustomGptAdminMutationResult.java
@@ -37,6 +37,23 @@ public class GqlCustomGptAdminMutationResult {
     private static final Logger LOGGER = LoggerFactory.getLogger(GqlCustomGptAdminMutationResult.class);
     private static final String CUSTOM_GPT_ADMIN = "customGptAdmin";
     private static final String CONFIG_PID = "org.jahia.community.modules.customgpt";
+    // Generic client-facing message; the underlying exception detail is logged server-side, never returned.
+    private static final String ERR_OPERATION_FAILED = "The CustomGPT operation could not be completed";
+    // Site keys are admin-supplied JCR node names; restrict to word chars and hyphen to avoid path traversal/injection.
+    private static final java.util.regex.Pattern SITE_KEY_PATTERN = java.util.regex.Pattern.compile("^[\\w-]+$");
+
+    /**
+     * Returns the acting user's name, sanitised for log output (CR/LF stripped). Used to attribute privileged
+     * admin mutations (purge, saveSettings, addSite, startIndex) in the server audit log.
+     */
+    private static String currentUserForAudit() {
+        try {
+            final org.jahia.services.usermanager.JahiaUser user = JCRSessionFactory.getInstance().getCurrentUser();
+            return SecurityUtils.sanitizeForLog(user != null ? user.getUsername() : "<unknown>");
+        } catch (RuntimeException e) {
+            return "<unknown>";
+        }
+    }
 
     @GraphQLName("Status")
     @GraphQLDescription("Status of the site added successfully to customGPT or already added")
@@ -79,7 +96,12 @@ public class GqlCustomGptAdminMutationResult {
         try {
             checkAdminPermission(CustomGptConstants.PATH_DELIMITER, CUSTOM_GPT_ADMIN);
         } catch (RepositoryException e) {
-            throw new DataFetchingException(e);
+            LOGGER.warn("Permission check failed for startIndex", e);
+            throw new DataFetchingException(ERR_OPERATION_FAILED);
+        }
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("[audit] startIndex requested by user {} for siteKeys {}", currentUserForAudit(),
+                    SecurityUtils.sanitizeForLog(String.valueOf(siteKeys)));
         }
         final Service customGptService = BundleUtils.getOsgiService(Service.class, null);
         if (customGptService == null) {
@@ -111,7 +133,12 @@ public class GqlCustomGptAdminMutationResult {
         try {
             checkAdminPermission(CustomGptConstants.PATH_DELIMITER, CUSTOM_GPT_ADMIN);
         } catch (RepositoryException e) {
-            throw new DataFetchingException(e);
+            LOGGER.warn("Permission check failed for startNodeIndex", e);
+            throw new DataFetchingException(ERR_OPERATION_FAILED);
+        }
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("[audit] startNodeIndex requested by user {} for nodePaths {}", currentUserForAudit(),
+                    SecurityUtils.sanitizeForLog(String.valueOf(nodePaths)));
         }
         final GqlIndexingJob job = NodeReindexAsyncJob.triggerJob(nodePaths, inclDescendants != null && inclDescendants);
         return new GqlIndexMutationResult(Collections.singletonList(job));
@@ -147,14 +174,17 @@ public class GqlCustomGptAdminMutationResult {
     @GraphQLName("addSite")
     @GraphQLDescription("Add site to the list of indexed sites")
     public String addSite(@GraphQLName(CustomGptConstants.PROP_SITE_KEY) @GraphQLNonNull @GraphQLDescription("Site key") String siteKey) {
-
+        // Validate the admin-supplied site key before building a JCR path to prevent path traversal / injection.
+        if (siteKey == null || !SITE_KEY_PATTERN.matcher(siteKey).matches()) {
+            throw new DataFetchingException(new IllegalArgumentException("Invalid site key; expected ^[\\w-]+$"));
+        }
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("[audit] addSite requested by user {} for siteKey {}", currentUserForAudit(),
+                    SecurityUtils.sanitizeForLog(siteKey));
+        }
         try {
             checkAdminPermission(CustomGptConstants.PATH_DELIMITER, CUSTOM_GPT_ADMIN);
             return JCRTemplate.getInstance().doExecuteWithSystemSession(session -> {
-                if ("".equals(siteKey)) {
-                    throw new RepositoryException("Site '/sites/' does not exist. Provide a valid site key.");
-                }
-
                 final String path = CustomGptConstants.PATH_SITES + siteKey;
                 checkAdminPermission(path, CustomGptConstants.PERM_SITE_ADMIN);
                 final JCRNodeWrapper site = session.getNode(path);
@@ -166,7 +196,8 @@ public class GqlCustomGptAdminMutationResult {
                 return Status.EXISTALREADY.getValue();
             });
         } catch (RepositoryException e) {
-            throw new DataFetchingException(e);
+            LOGGER.warn("addSite failed for siteKey {}", SecurityUtils.sanitizeForLog(siteKey), e);
+            throw new DataFetchingException(ERR_OPERATION_FAILED);
         }
     }
 
@@ -193,7 +224,11 @@ public class GqlCustomGptAdminMutationResult {
         try {
             checkAdminPermission(CustomGptConstants.PATH_DELIMITER, CUSTOM_GPT_ADMIN);
         } catch (RepositoryException e) {
-            throw new DataFetchingException(e);
+            LOGGER.warn("Permission check failed for saveSettings", e);
+            throw new DataFetchingException(ERR_OPERATION_FAILED);
+        }
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("[audit] saveSettings requested by user {}", currentUserForAudit());
         }
         // The base URL travels with the Bearer token on every API call; reject anything that is not https to
         // prevent the token from being exfiltrated over cleartext or to a non-HTTP scheme.
@@ -237,7 +272,7 @@ public class GqlCustomGptAdminMutationResult {
             }
             config.update(props);
             return Boolean.TRUE;
-        } catch (Exception e) {
+        } catch (java.io.IOException e) {
             LOGGER.error("Failed to save CustomGPT settings", e);
             return Boolean.FALSE;
         }
@@ -250,7 +285,11 @@ public class GqlCustomGptAdminMutationResult {
         try {
             checkAdminPermission(CustomGptConstants.PATH_DELIMITER, CUSTOM_GPT_ADMIN);
         } catch (RepositoryException e) {
-            throw new DataFetchingException(e);
+            LOGGER.warn("Permission check failed for purgeAllPages", e);
+            throw new DataFetchingException(ERR_OPERATION_FAILED);
+        }
+        if (LOGGER.isWarnEnabled()) {
+            LOGGER.warn("[audit] purgeAllPages (danger zone) requested by user {}", currentUserForAudit());
         }
         final Service customGptService = BundleUtils.getOsgiService(Service.class, null);
         if (customGptService == null) {
@@ -258,8 +297,9 @@ public class GqlCustomGptAdminMutationResult {
         }
         try {
             return customGptService.purgeAllPages();
-        } catch (Exception e) {
-            throw new DataFetchingException(e);
+        } catch (java.io.IOException e) {
+            LOGGER.error("purgeAllPages failed", e);
+            throw new DataFetchingException(ERR_OPERATION_FAILED);
         }
     }
 

--- a/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/query/AdminQueries.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/graphql/extensions/query/AdminQueries.java
@@ -16,6 +16,8 @@ import org.jahia.community.modules.customgpt.util.SecurityUtils;
 import org.jahia.modules.graphql.provider.dxm.DataFetchingException;
 import org.jahia.osgi.BundleUtils;
 import org.jahia.services.content.JCRSessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * GraphQL query resolver for the {@code admin.customGpt} namespace.
@@ -28,7 +30,10 @@ import org.jahia.services.content.JCRSessionFactory;
 @GraphQLDescription("List of indexed sites entry point")
 public class AdminQueries {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdminQueries.class);
     private static final String CUSTOM_GPT_ADMIN = "customGptAdmin";
+    private static final String ERR_PERMISSION = "Access denied or unable to verify permissions";
+    private static final String ERR_SETTINGS = "Unable to load CustomGPT settings";
 
     @GraphQLField
     @GraphQLName("listSites")
@@ -37,7 +42,9 @@ public class AdminQueries {
         try {
             checkAdminPermission(CustomGptConstants.PATH_DELIMITER, CUSTOM_GPT_ADMIN);
         } catch (RepositoryException e) {
-            throw new DataFetchingException(e);
+            // Log the detail server-side; return a generic message so internal paths/JCR detail are not leaked.
+            LOGGER.warn("Permission check failed for listSites", e);
+            throw new DataFetchingException(ERR_PERMISSION);
         }
         final Collection<Site> indexedSites = BundleUtils.getOsgiService(Service.class, null).getIndexedSites().values();
         return new GqlSiteListModel(indexedSites);
@@ -50,7 +57,8 @@ public class AdminQueries {
         try {
             checkAdminPermission(CustomGptConstants.PATH_DELIMITER, CUSTOM_GPT_ADMIN);
         } catch (RepositoryException e) {
-            throw new DataFetchingException(e);
+            LOGGER.warn("Permission check failed for settings", e);
+            throw new DataFetchingException(ERR_PERMISSION);
         }
         final Config config = BundleUtils.getOsgiService(Config.class, null);
         if (config == null || !config.isConfigured()) {
@@ -86,7 +94,8 @@ public class AdminQueries {
                     .rateLimitRequestsPerSecond(config.getRateLimitRequestsPerSecond())
                     .build();
         } catch (org.jahia.community.modules.customgpt.settings.NotConfiguredException e) {
-            throw new DataFetchingException(e);
+            LOGGER.warn("Unable to read CustomGPT settings", e);
+            throw new DataFetchingException(ERR_SETTINGS);
         }
     }
 

--- a/src/main/java/org/jahia/community/modules/customgpt/indexer/CustomGptIndexerNodeHandler.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/indexer/CustomGptIndexerNodeHandler.java
@@ -2,8 +2,10 @@ package org.jahia.community.modules.customgpt.indexer;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -12,6 +14,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
 import javax.jcr.RepositoryException;
+import javax.servlet.ServletException;
 import okhttp3.Credentials;
 import okhttp3.FormBody;
 import okhttp3.MediaType;
@@ -33,7 +36,6 @@ import org.jahia.community.modules.customgpt.util.HttpServletRequestMock;
 import org.jahia.community.modules.customgpt.util.HttpServletResponseMock;
 import org.jahia.community.modules.customgpt.util.SecurityUtils;
 import org.jahia.community.modules.customgpt.util.Utils;
-import org.jahia.services.content.JCRCallback;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.content.JCRTemplate;
@@ -153,7 +155,7 @@ final class CustomGptIndexerNodeHandler {
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
             LOGGER.error("Issue:", ex);
-        } catch (Exception ex) {
+        } catch (RepositoryException | IOException | ServletException | InvocationTargetException | URISyntaxException ex) {
             LOGGER.error("Issue:", ex);
         }
     }
@@ -232,30 +234,24 @@ final class CustomGptIndexerNodeHandler {
     }
 
     private static String getExistingPageId(JahiaUser rootUser, String nodePath) throws RepositoryException {
-        return JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(rootUser, Constants.EDIT_WORKSPACE, null, new JCRCallback<String>() {
-            @Override
-            public String doInJCR(JCRSessionWrapper session) throws RepositoryException {
-                final String mappingPath = CustomGptConstants.buildMappingPath(nodePath);
-                if (session.nodeExists(mappingPath)) {
-                    final JCRNodeWrapper node = session.getNode(mappingPath);
-                    if (node.hasProperty(CustomGptConstants.PROP_CUSTOM_GPT_PAGE_ID)) {
-                        return node.getProperty(CustomGptConstants.PROP_CUSTOM_GPT_PAGE_ID).getString();
-                    }
+        return JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(rootUser, Constants.EDIT_WORKSPACE, null, session -> {
+            final String mappingPath = CustomGptConstants.buildMappingPath(nodePath);
+            if (session.nodeExists(mappingPath)) {
+                final JCRNodeWrapper node = session.getNode(mappingPath);
+                if (node.hasProperty(CustomGptConstants.PROP_CUSTOM_GPT_PAGE_ID)) {
+                    return node.getProperty(CustomGptConstants.PROP_CUSTOM_GPT_PAGE_ID).getString();
                 }
-                return null;
             }
+            return null;
         });
     }
 
     private static void writeMappingNode(JahiaUser rootUser, String nodePath, String pageId) throws RepositoryException {
-        JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(rootUser, Constants.EDIT_WORKSPACE, null, new JCRCallback<Void>() {
-            @Override
-            public Void doInJCR(JCRSessionWrapper session) throws RepositoryException {
-                final JCRNodeWrapper mappingNode = getOrCreateMappingNode(session, nodePath);
-                mappingNode.setProperty(CustomGptConstants.PROP_CUSTOM_GPT_PAGE_ID, pageId);
-                session.save();
-                return null;
-            }
+        JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(rootUser, Constants.EDIT_WORKSPACE, null, session -> {
+            final JCRNodeWrapper mappingNode = getOrCreateMappingNode(session, nodePath);
+            mappingNode.setProperty(CustomGptConstants.PROP_CUSTOM_GPT_PAGE_ID, pageId);
+            session.save();
+            return null;
         });
     }
 

--- a/src/main/java/org/jahia/community/modules/customgpt/indexer/Indexer.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/indexer/Indexer.java
@@ -2,8 +2,6 @@ package org.jahia.community.modules.customgpt.indexer;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.query.Query;
@@ -36,7 +34,6 @@ import org.slf4j.LoggerFactory;
 public class Indexer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Indexer.class);
-    private static final Map<String, AtomicInteger> nodeToReindex = new ConcurrentHashMap<>();
     private final Map<String, String> nodePathsToMove = new LinkedHashMap<>();
     private final Set<String> customGptPageToRemove = new LinkedHashSet<>();
     private final Set<String> nodePathsToAddOrReIndex = new LinkedHashSet<>();
@@ -159,9 +156,6 @@ public class Indexer {
                 || nodeWrapper.isNodeType(Constants.JAHIANT_CONDITION)) {
             return getContentNode(nodeWrapper.getParent());
         }
-        if (nodeWrapper.isNodeType(Constants.JAHIANT_ACE)) {
-            return getContentNode(nodeWrapper.getParent());
-        }
         return nodeWrapper;
     }
 
@@ -175,8 +169,6 @@ public class Indexer {
             final JCRSiteNode siteNode = (JCRSiteNode) node;
             if (siteNode.getPath().startsWith(CustomGptConstants.PATH_SITES)) {
                 LOGGER.info("Indexing site {}...", siteNode.getPath());
-                clearNodeToReindex();
-                LOGGER.info("We cleared all blocked nodes from before reindexation.");
                 addNodesToIndex(customGptClient, jahiaClient, siteNode);
                 LOGGER.info("Finished indexing site {}", siteNode.getPath());
             }
@@ -317,9 +309,5 @@ public class Indexer {
         protected Void getResult() {
             return null;
         }
-    }
-
-    private static void clearNodeToReindex() {
-        nodeToReindex.clear();
     }
 }

--- a/src/main/java/org/jahia/community/modules/customgpt/indexer/listener/IndexOperations.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/indexer/listener/IndexOperations.java
@@ -114,7 +114,9 @@ public class IndexOperations implements Serializable {
 
         @Override
         public int hashCode() {
-            return Objects.hash(type, nodePath, sourcePath, siteKey, customGptPageId);
+            // Must use the SAME fields as equals(); otherwise two operations that are equal() can land in different
+            // buckets and the LinkedHashSet dedup in IndexOperations silently fails to drop duplicates.
+            return Objects.hash(type, nodePath, customGptPageId);
         }
 
         @Override
@@ -133,9 +135,8 @@ public class IndexOperations implements Serializable {
     }
 
     public void addOperation(CustomGptIndexOperation operation) {
-        if (!operations.contains(operation)) {
-            operations.add(operation);
-        }
+        // operations is a Set, so add() already dedups via equals()/hashCode().
+        operations.add(operation);
     }
 
     public Set<CustomGptIndexOperation> getOperations() {
@@ -148,7 +149,7 @@ public class IndexOperations implements Serializable {
     }
 
     public boolean isEmpty() {
-        return operations == null || operations.isEmpty();
+        return operations.isEmpty();
     }
 
     public String getSiteKey() {

--- a/src/main/java/org/jahia/community/modules/customgpt/indexer/listener/IndexerJCRListener.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/indexer/listener/IndexerJCRListener.java
@@ -91,7 +91,7 @@ public class IndexerJCRListener extends DefaultEventListener {
     }
 
     private static String computeNodePath(String path, int type) {
-        final boolean isPropertyEvent = (type | PROPERTY_EVENTS) == PROPERTY_EVENTS;
+        final boolean isPropertyEvent = (type & PROPERTY_EVENTS) != 0;
         if (isPropertyEvent) {
             final int endIndex = path.lastIndexOf(CustomGptConstants.PATH_DELIMITER);
             return path.substring(0, endIndex);
@@ -116,7 +116,7 @@ public class IndexerJCRListener extends DefaultEventListener {
                     } else if (isSubNodeType(nodeWrapper)) {
                         processEvent(new CustomEvent(Event.NODE_REMOVED, identifier, nodePath), nodePath, customGptIndexOperations);
                     }
-                } catch (Exception e) {
+                } catch (RepositoryException | NotConfiguredException e) {
                     LOGGER.warn("Error processing JCR event for skip-index mixin on node {}", identifier, e);
                 }
                 return null;
@@ -143,7 +143,7 @@ public class IndexerJCRListener extends DefaultEventListener {
                     } else if (isSubNodeType(nodeWrapper)) {
                         processEvent(new CustomEvent(Event.NODE_REMOVED, identifier, nodePath), nodePath, customGptIndexOperations);
                     }
-                } catch (Exception e) {
+                } catch (RepositoryException | NotConfiguredException e) {
                     LOGGER.warn("Error processing trash JCR event for node {}", identifier, e);
                 }
                 return null;
@@ -164,7 +164,7 @@ public class IndexerJCRListener extends DefaultEventListener {
                     } else if (isSubNodeType(nodeWrapper)) {
                         queueIndexationForSubNodeParents(event, nodeWrapper, mainResourceTypes, customGptIndexOperations);
                     }
-                } catch (Exception e) {
+                } catch (RepositoryException | NotConfiguredException e) {
                     LOGGER.error("Error processing events in the customGpt listener", e);
                 }
                 return null;
@@ -215,10 +215,6 @@ public class IndexerJCRListener extends DefaultEventListener {
                 customGptIndexOperations.addOperation(operation);
                 break;
             case Event.PROPERTY_ADDED:
-                if (event.getPath().endsWith("/j:lastPublished")) {
-                    addIndexOperation(nodePath, customGptIndexOperations);
-                }
-                break;
             case Event.PROPERTY_CHANGED:
                 if (event.getPath().endsWith("/j:lastPublished")) {
                     addIndexOperation(nodePath, customGptIndexOperations);
@@ -235,21 +231,18 @@ public class IndexerJCRListener extends DefaultEventListener {
 
     private void findAndQueueMappingRemoval(String nodePath, IndexOperations operations) {
         try {
-            JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(null, Constants.EDIT_WORKSPACE, null, new JCRCallback<Void>() {
-                @Override
-                public Void doInJCR(JCRSessionWrapper editSession) throws RepositoryException {
-                    final String mappingPath = CustomGptConstants.buildMappingPath(nodePath);
-                    if (editSession.nodeExists(mappingPath)) {
-                        final JCRNodeWrapper mappingNode = editSession.getNode(mappingPath);
-                        if (mappingNode.hasProperty(CustomGptConstants.PROP_CUSTOM_GPT_PAGE_ID)) {
-                            final String pageId = mappingNode.getProperty(CustomGptConstants.PROP_CUSTOM_GPT_PAGE_ID).getString();
-                            processEvent(new CustomEvent(Event.NODE_REMOVED, null, null, pageId), null, operations);
-                        }
-                        mappingNode.remove();
-                        editSession.save();
+            JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(null, Constants.EDIT_WORKSPACE, null, editSession -> {
+                final String mappingPath = CustomGptConstants.buildMappingPath(nodePath);
+                if (editSession.nodeExists(mappingPath)) {
+                    final JCRNodeWrapper mappingNode = editSession.getNode(mappingPath);
+                    if (mappingNode.hasProperty(CustomGptConstants.PROP_CUSTOM_GPT_PAGE_ID)) {
+                        final String pageId = mappingNode.getProperty(CustomGptConstants.PROP_CUSTOM_GPT_PAGE_ID).getString();
+                        processEvent(new CustomEvent(Event.NODE_REMOVED, null, null, pageId), null, operations);
                     }
-                    return null;
+                    mappingNode.remove();
+                    editSession.save();
                 }
+                return null;
             });
         } catch (RepositoryException e) {
             LOGGER.warn("Error accessing CustomGPT mapping node for node path {}", nodePath, e);
@@ -259,7 +252,7 @@ public class IndexerJCRListener extends DefaultEventListener {
     private void tryQueueMappingRemoval(JCRNodeWrapper node, String identifier, IndexOperations ops) {
         try {
             findAndQueueMappingRemoval(node.getPath(), ops);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             LOGGER.warn("Cannot resolve path for node {}, skipping CustomGPT cleanup", identifier, e);
         }
     }

--- a/src/main/java/org/jahia/community/modules/customgpt/service/Service.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/service/Service.java
@@ -86,6 +86,11 @@ public class Service implements EventHandler {
     private static final String RECREATE_LOG = "Recreate Log";
     private static final int N_THREADS = 2;
     private static final int DEFAULT_BATCH_SIZE = 10;
+    // OkHttp timeouts: bound every outbound CustomGPT/Jahia call so a stalled peer cannot pin a worker thread forever.
+    private static final int CONNECT_TIMEOUT_SECONDS = 10;
+    private static final int READ_TIMEOUT_SECONDS = 30;
+    private static final int WRITE_TIMEOUT_SECONDS = 30;
+    private static final int CALL_TIMEOUT_SECONDS = 60;
     private static final String HEADER_AUTHORIZATION = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String HEADER_ACCEPT = "accept";
@@ -103,9 +108,18 @@ public class Service implements EventHandler {
     private String journalEventReaderKey;
     private volatile boolean initialized;
     private boolean journalEventReaderEnabled;
-    private int retryOnConflict;
     private OkHttpClient customGptClient;
     private OkHttpClient jahiaClient;
+    // Executors are restarted on demand by the synchronized restartExecutor* guards; volatile so a fresh pool
+    // published by one thread is visible to the producers reading the field. The volatile reference is only ever
+    // swapped inside synchronized restartExecutor* methods, so volatile (not AtomicReference) is the intended
+    // design here.
+    @SuppressWarnings("java:S3077")
+    private volatile ExecutorService executor = Executors.newFixedThreadPool(1);
+    @SuppressWarnings("java:S3077")
+    private volatile ExecutorService executorFullIndexation = Executors.newFixedThreadPool(1);
+    @SuppressWarnings("java:S3077")
+    private volatile ExecutorService executorNThreads = Executors.newFixedThreadPool(N_THREADS);
     
     @Activate
     public void activate(BundleContext bundleContext) {
@@ -269,37 +283,34 @@ public class Service implements EventHandler {
         CompletableFuture.runAsync(() -> {
             try {
                 performIndexation(operations);
-            } catch (Exception e) {
+            } catch (RepositoryException | IOException e) {
                 LOGGER.error("Indexation failed due to: {}", e.getMessage(), e);
             }
         }, executorFullIndexation);
     }
     
-    private void restartExecutor() {
+    // Guarded so concurrent producers cannot race the shutdown/terminated check and lose tasks to a dead pool.
+    private synchronized void restartExecutor() {
         if (executor.isShutdown() || executor.isTerminated()) {
             LOGGER.warn("Executor is shutdown or terminated, starting a new one");
             executor = Executors.newFixedThreadPool(1);
         }
     }
-    
-    private void restartExecutorFullIndexation() {
+
+    private synchronized void restartExecutorFullIndexation() {
         if (executorFullIndexation.isShutdown() || executorFullIndexation.isTerminated()) {
             LOGGER.warn("ExecutorFullIndexation is shutdown or terminated, starting a new one");
             executorFullIndexation = Executors.newFixedThreadPool(1);
         }
     }
-    
-    private void restartExecutorNThreads() {
+
+    private synchronized void restartExecutorNThreads() {
         if (executorNThreads.isShutdown() || executorNThreads.isTerminated()) {
             LOGGER.warn("Executor with {} threads is shutdown or terminated, starting a new one", N_THREADS);
             executorNThreads = Executors.newFixedThreadPool(N_THREADS);
         }
     }
-    
-    private ExecutorService executor = Executors.newFixedThreadPool(1);
-    private ExecutorService executorFullIndexation = Executors.newFixedThreadPool(1);
-    private ExecutorService executorNThreads = Executors.newFixedThreadPool(N_THREADS);
-    
+
     public void produceAsynchronousOperations(IndexOperations... operations) {
         restartExecutor();
         final CompletableFuture<Void>[] completableFuture = new CompletableFuture[operations.length];
@@ -339,7 +350,7 @@ public class Service implements EventHandler {
         return () -> {
             try {
                 performIndexation(operations);
-            } catch (Exception e) {
+            } catch (RepositoryException | IOException e) {
                 LOGGER.error("Indexation failed due to: {}", e.getMessage(), e);
             }
             return null;
@@ -558,7 +569,7 @@ public class Service implements EventHandler {
         this.jahiaTemplateManagerService = jahiaTemplateManagerService;
     }
     
-    private void init() {
+    private synchronized void init() {
         if (!initialized) {
             LOGGER.info("Starting service...");
             if (settingsBean.isProcessingServer()) {
@@ -591,12 +602,20 @@ public class Service implements EventHandler {
                         // Do not follow redirects: the session cookie must not be forwarded to redirect destinations.
                         .followRedirects(false)
                         .followSslRedirects(false)
+                        .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                        .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                        .writeTimeout(WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                        .callTimeout(CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                         .build();
                 customGptClient = new OkHttpClient.Builder()
                         // Do not follow redirects: every request carries the Bearer token, and a redirect to another
                         // host could forward the Authorization header to an attacker-controlled endpoint.
                         .followRedirects(false)
                         .followSslRedirects(false)
+                        .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                        .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                        .writeTimeout(WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                        .callTimeout(CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                         .authenticator((route, response) -> {
                             if (response.request().header(HEADER_AUTHORIZATION) != null) {
                                 return null;
@@ -674,15 +693,7 @@ public class Service implements EventHandler {
     public void setJournalEventReaderEnabled(boolean journalEventReaderEnabled) {
         this.journalEventReaderEnabled = journalEventReaderEnabled;
     }
-    
-    public int getRetryOnConflict() {
-        return retryOnConflict;
-    }
-    
-    public void setRetryOnConflict(int retryOnConflict) {
-        this.retryOnConflict = retryOnConflict;
-    }
-    
+
     /**
      * Receives OSGi events from {@link CustomGptConstants#EVENT_TOPIC}.
      * On {@link CustomGptConstants#EVENT_TYPE_CONFIG_UPDATED_REQUIRE_REINDEX} it re-initialises the HTTP clients,
@@ -718,14 +729,14 @@ public class Service implements EventHandler {
                 return;
             }
             final org.osgi.service.cm.Configuration config = configAdmin.getConfiguration("org.jahia.community.modules.customgpt", null);
-            java.util.Dictionary<String, Object> props = config.getProperties();
+            Dictionary<String, Object> props = config.getProperties();
             if (props == null) {
-                props = new java.util.Hashtable<>();
+                props = new Hashtable<>();
             }
             props.put("org.jahia.community.modules.customgpt.scheduleJobASAP", Boolean.FALSE);
             config.update(props);
             LOGGER.info("Reset scheduleJobASAP to false after scheduling indexation jobs");
-        } catch (Exception e) {
+        } catch (IOException e) {
             LOGGER.warn("Failed to reset scheduleJobASAP property: {}", e.getMessage());
         }
     }
@@ -809,15 +820,12 @@ public class Service implements EventHandler {
     }
     
     private void updateIndexationTime(String path, String property, Calendar date) throws RepositoryException {
-        JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback<Object>() {
-            @Override
-            public Object doInJCR(JCRSessionWrapper session) throws RepositoryException {
-                final JCRNodeWrapper node = session.getNode(path);
-                node.setProperty(property, date);
-                session.save();
-                LOGGER.info("Site {} indexation has {} at {}", path, (property.equals(PROP_INDEXATION_START) ? "started" : "ended"), date.toInstant());
-                return null;
-            }
+        JCRTemplate.getInstance().doExecuteWithSystemSession(session -> {
+            final JCRNodeWrapper node = session.getNode(path);
+            node.setProperty(property, date);
+            session.save();
+            LOGGER.info("Site {} indexation has {} at {}", path, (property.equals(PROP_INDEXATION_START) ? "started" : "ended"), date.toInstant());
+            return null;
         });
     }
     
@@ -830,6 +838,11 @@ public class Service implements EventHandler {
     }
     
     public JCRSessionWrapper getSystemSession(JahiaUser user, String workspace, Locale locale) throws RepositoryException {
+        // NOTE: setCurrentUser mutates the thread-local JCRSessionFactory current user as a side effect, which is a
+        // shared-state concern when indexer tasks run on pooled executor threads. It is left in place deliberately:
+        // the index pipeline relies on the current-user being the root/system user for permission resolution, and a
+        // safe behaviour-preserving fix would require threading the user through the call chain. Do not "fix" by
+        // removing the guard without also passing the user explicitly to every downstream JCR call.
         final JCRSessionWrapper systemSession = JCRTemplate.getInstance().getSessionFactory().getCurrentSystemSession(workspace, locale, null);
         if (JCRSessionFactory.getInstance().getCurrentUser() == null) {
             JCRSessionFactory.getInstance().setCurrentUser(user);

--- a/src/main/java/org/jahia/community/modules/customgpt/settings/Config.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/settings/Config.java
@@ -5,6 +5,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.nodetype.NoSuchNodeTypeException;
 import org.apache.commons.lang.StringUtils;
 import org.jahia.community.modules.customgpt.CustomGptConstants;
+import org.jahia.community.modules.customgpt.util.SecurityUtils;
 import org.jahia.osgi.FrameworkService;
 import org.jahia.services.content.nodetypes.NodeTypeRegistry;
 import org.osgi.service.cm.ConfigurationException;
@@ -28,13 +29,13 @@ public class Config implements ManagedService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Config.class);
     private static final String JMIX_MAIN_RESOURCE = "jmix:mainResource";
-    private static final int FIVE_HUNDRED = 500;
+    private static final int DEFAULT_BULK_OPERATIONS_BATCH_SIZE = 500;
 
     private static final String CONFIG_NAMESPACE_PREFIX = "org.jahia.community.modules.customgpt";
     private static final String PROP_CONTENT_INDEXED_SUB_NODE_TYPES = CONFIG_NAMESPACE_PREFIX + ".content.indexedSubNodeTypes";
     private static final String PROP_CONTENT_INDEXED_MAIN_RESOURCE_TYPES = CONFIG_NAMESPACE_PREFIX + ".content.indexedMainResourceTypes";
-    private static final String PROP_GUSTOM_GPT_PROJECT_ID = CONFIG_NAMESPACE_PREFIX + ".projectId";
-    private static final String PROP_GUSTOM_GPT_TOKEN = CONFIG_NAMESPACE_PREFIX + ".token";
+    private static final String PROP_CUSTOM_GPT_PROJECT_ID = CONFIG_NAMESPACE_PREFIX + ".projectId";
+    private static final String PROP_CUSTOM_GPT_TOKEN = CONFIG_NAMESPACE_PREFIX + ".token";
     private static final String PROP_JAHIA_USERNAME = CONFIG_NAMESPACE_PREFIX + ".jahia.username";
     private static final String PROP_JAHIA_PASSWORD = CONFIG_NAMESPACE_PREFIX + ".jahia.password";
     private static final String PROP_JAHIA_SERVER_COOKIE_NAME = CONFIG_NAMESPACE_PREFIX + ".jahia.serverCookie.name";
@@ -75,6 +76,14 @@ public class Config implements ManagedService {
             return;
         }
         parse(properties);
+        // The apiBaseUrl travels with the Bearer token on every API call. A .cfg edit bypasses the saveSettings UI
+        // gate, so re-validate here: reject anything that is not a public https:// URL and refuse to mark the
+        // service configured, rather than letting the token be sent over cleartext or to an internal SSRF target.
+        if (StringUtils.isNotEmpty(customGptApiBaseUrl) && !SecurityUtils.isHttpsUrl(customGptApiBaseUrl)) {
+            LOGGER.error("CustomGpt apiBaseUrl is not a valid public https:// URL; configuration rejected");
+            configured = false;
+            return;
+        }
         configured = true;
         final String eventType = scheduleJobASAP
                 ? CustomGptConstants.EVENT_TYPE_CONFIG_UPDATED_REQUIRE_REINDEX
@@ -115,15 +124,15 @@ public class Config implements ManagedService {
         contentIndexedSubNodes = splitNodeTypeByComma((String) properties.get(PROP_CONTENT_INDEXED_SUB_NODE_TYPES));
         contentIndexedMainResources = splitNodeTypeByComma((String) properties.get(PROP_CONTENT_INDEXED_MAIN_RESOURCE_TYPES));
         updateSetToExcludeMainResourceType(contentIndexedMainResources);
-        bulkOperationsBatchSize = getInt(properties, BULK_OPERATIONS_BATCH_SIZE, FIVE_HUNDRED);
+        bulkOperationsBatchSize = getInt(properties, BULK_OPERATIONS_BATCH_SIZE, DEFAULT_BULK_OPERATIONS_BATCH_SIZE);
 
         final String indexedFiles = (String) properties.get(CONTENT_INDEXED_FILE_EXTENSIONS);
         if (StringUtils.isEmpty(StringUtils.trim(indexedFiles))) {
             indexedFileExtensions = Collections.emptySet();
         } else {
+            // indexedFiles is non-blank here (the isEmpty branch above handles null/blank), so no null guard needed.
             indexedFileExtensions = new LinkedHashSet<>();
-            String[] parts = (indexedFiles == null ? "*" : indexedFiles).split(",");
-            for (String part : parts) {
+            for (String part : indexedFiles.split(",")) {
                 String trimmed = part.trim();
                 if (!trimmed.isEmpty()) {
                     indexedFileExtensions.add(trimmed);
@@ -136,8 +145,8 @@ public class Config implements ManagedService {
         customGptApiBaseUrl = getString(properties, PROP_CUSTOM_GPT_API_BASE_URL, CustomGptConstants.DEFAULT_CUSTOM_GPT_API_BASE_URL);
         rateLimitRequestsPerSecond = getInt(properties, PROP_RATE_LIMIT_REQUESTS_PER_SECOND, 10);
 
-        customGptProjectId = getString(properties, PROP_GUSTOM_GPT_PROJECT_ID, "");
-        customGptToken = getString(properties, PROP_GUSTOM_GPT_TOKEN, "");
+        customGptProjectId = getString(properties, PROP_CUSTOM_GPT_PROJECT_ID, "");
+        customGptToken = getString(properties, PROP_CUSTOM_GPT_TOKEN, "");
         jahiaUsername = getString(properties, PROP_JAHIA_USERNAME, "");
         jahiaPassword = getString(properties, PROP_JAHIA_PASSWORD, "");
         jahiaServerCookieName = getString(properties, PROP_JAHIA_SERVER_COOKIE_NAME, "");
@@ -167,37 +176,30 @@ public class Config implements ManagedService {
     }
 
     private int getInt(Dictionary<String, ?> properties, String key, int def) {
-        if (properties.get(key) != null) {
-            final Object val = properties.get(key);
-            if (val instanceof Number) {
-                return ((Number) val).intValue();
-            } else if (val != null) {
-                return Integer.parseInt(val.toString());
-            }
+        final Object val = properties.get(key);
+        if (val == null) {
+            return def;
         }
-        return def;
+        if (val instanceof Number) {
+            return ((Number) val).intValue();
+        }
+        return Integer.parseInt(val.toString());
     }
 
     private boolean getBoolean(Dictionary<String, ?> properties, String key, boolean def) {
-        if (properties.get(key) != null) {
-            final Object val = properties.get(key);
-            if (val instanceof Boolean) {
-                return (Boolean) val;
-            } else if (val != null) {
-                return Boolean.parseBoolean(val.toString());
-            }
+        final Object val = properties.get(key);
+        if (val == null) {
+            return def;
         }
-        return def;
+        if (val instanceof Boolean) {
+            return (Boolean) val;
+        }
+        return Boolean.parseBoolean(val.toString());
     }
 
     private String getString(Dictionary<String, ?> properties, String key, String def) {
-        if (properties.get(key) != null) {
-            final Object val = properties.get(key);
-            if (val != null) {
-                return val.toString();
-            }
-        }
-        return def;
+        final Object val = properties.get(key);
+        return val != null ? val.toString() : def;
     }
 
     public boolean isConfigured() {

--- a/src/main/java/org/jahia/community/modules/customgpt/util/SecurityUtils.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/util/SecurityUtils.java
@@ -113,21 +113,32 @@ public final class SecurityUtils {
     }
 
     /**
-     * Returns {@code true} only when {@code value} is a numeric IPv4 (dotted-quad) or IPv6 literal, so that
-     * {@link InetAddress#getByName(String)} resolves it locally without a DNS round-trip.
+     * Returns {@code true} only when {@code value} is a numeric IP literal that {@link InetAddress#getByName(String)}
+     * resolves locally without a DNS round-trip: an IPv6 literal (contains a colon), a dotted IPv4 literal, OR a
+     * dotless numeric form (decimal/integer, e.g. {@code 2130706433} for {@code 127.0.0.1} or {@code 0} for
+     * {@code 0.0.0.0}). Java's resolver — and therefore OkHttp — collapses these dotless forms to real loopback/any
+     * addresses, so they MUST be range-checked rather than treated as opaque hostnames (SSRF bypass). An all-digits
+     * string can never be a registrable DNS hostname, so accepting it here introduces no DNS lookup of a real host.
      */
     private static boolean isIpLiteral(String value) {
-        // IPv6 literals contain a colon; an IPv4 literal is digits-and-dots only.
+        // IPv6 literals contain a colon.
         if (value.indexOf(':') >= 0) {
             return true;
         }
+        boolean hasDigit = false;
         for (int i = 0; i < value.length(); i++) {
             final char c = value.charAt(i);
-            if (c != '.' && (c < '0' || c > '9')) {
+            if (c == '.') {
+                continue;
+            }
+            if (c < '0' || c > '9') {
+                // A real hostname (contains a non-digit, non-dot character) — not an IP literal.
                 return false;
             }
+            hasDigit = true;
         }
-        return value.indexOf('.') >= 0;
+        // All-digits (dotless decimal/integer) or dotted-numeric: a numeric IP literal.
+        return hasDigit;
     }
 
     /** Returns {@code true} for IPv6 unique-local addresses ({@code fc00::/7}), which Java does not flag directly. */

--- a/src/main/java/org/jahia/community/modules/customgpt/util/SecurityUtils.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/util/SecurityUtils.java
@@ -125,6 +125,14 @@ public final class SecurityUtils {
         if (value.indexOf(':') >= 0) {
             return true;
         }
+        // Hex IPv4 forms (e.g. 0x7f000001 or 0x7f.0.0.1): every numeric segment is prefixed with "0x"/"0X".
+        // Real hostnames never start with "0x", so classifying these as IP literals routes them through the
+        // range check (or InetAddress's UnknownHostException -> fail-safe) and closes the hex SSRF bypass
+        // without resolving any genuine hostname.
+        final String lower = value.toLowerCase(java.util.Locale.ROOT);
+        if (lower.startsWith("0x") || lower.contains(".0x")) {
+            return true;
+        }
         boolean hasDigit = false;
         for (int i = 0; i < value.length(); i++) {
             final char c = value.charAt(i);

--- a/src/main/java/org/jahia/community/modules/customgpt/util/SecurityUtils.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/util/SecurityUtils.java
@@ -1,7 +1,9 @@
 package org.jahia.community.modules.customgpt.util;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import org.apache.commons.lang.StringUtils;
 
 /**
@@ -51,9 +53,14 @@ public final class SecurityUtils {
     }
 
     /**
-     * Validates that {@code url} is an absolute {@code https://} URL with a host. Used to gate the configurable
-     * CustomGPT API base URL (which is sent together with the Bearer token) so the token cannot be exfiltrated over
-     * cleartext or to a non-HTTP scheme.
+     * Validates that {@code url} is an absolute {@code https://} URL with a host, and that the host is not a literal
+     * private/loopback/link-local/unique-local IP address. Used to gate the configurable CustomGPT API base URL
+     * (which is sent together with the Bearer token) and the Jahia rendering URL (which carries Basic auth) so the
+     * credential cannot be exfiltrated over cleartext, to a non-HTTP scheme, or to an internal SSRF target.
+     *
+     * <p>Hostnames are accepted as-is — no DNS resolution is performed (resolving an arbitrary attacker-supplied
+     * hostname would itself be an SSRF/DoS vector). Only literal IP-address hosts are checked against the
+     * private/internal ranges; see {@link #isInternalHost(String)}.
      */
     public static boolean isHttpsUrl(String url) {
         if (StringUtils.isEmpty(url)) {
@@ -61,10 +68,72 @@ public final class SecurityUtils {
         }
         try {
             final URI uri = new URI(url.trim());
-            return SCHEME_HTTPS.equalsIgnoreCase(uri.getScheme()) && StringUtils.isNotEmpty(uri.getHost());
+            final String host = uri.getHost();
+            return SCHEME_HTTPS.equalsIgnoreCase(uri.getScheme()) && StringUtils.isNotEmpty(host) && !isInternalHost(host);
         } catch (URISyntaxException e) {
             return false;
         }
+    }
+
+    /**
+     * Returns {@code true} when {@code host} is a <em>literal</em> IP address that falls in a private, loopback,
+     * link-local or unique-local range, which an outbound credential-bearing request must never target (SSRF).
+     * Covered ranges: {@code 10.0.0.0/8}, {@code 127.0.0.0/8}, {@code 169.254.0.0/16}, {@code 172.16.0.0/12},
+     * {@code 192.168.0.0/16}, {@code ::1} and {@code fc00::/7}.
+     *
+     * <p>Non-IP hostnames (e.g. {@code app.customgpt.ai}) are NOT resolved and return {@code false} — only a value
+     * that already parses as an IP literal is range-checked, so this method never performs DNS lookups.
+     *
+     * <p>This is package-friendly (public + static) so it can be unit-tested directly.
+     */
+    public static boolean isInternalHost(String host) {
+        if (StringUtils.isEmpty(host)) {
+            return false;
+        }
+        String candidate = host.trim();
+        // Strip the brackets used around IPv6 literals in URLs, e.g. "[::1]".
+        if (candidate.startsWith("[") && candidate.endsWith("]")) {
+            candidate = candidate.substring(1, candidate.length() - 1);
+        }
+        if (!isIpLiteral(candidate)) {
+            // A hostname, not an IP literal: do not resolve it (DNS lookups are themselves an SSRF/DoS risk).
+            return false;
+        }
+        try {
+            final InetAddress address = InetAddress.getByName(candidate);
+            return address.isLoopbackAddress()
+                    || address.isLinkLocalAddress()
+                    || address.isSiteLocalAddress()
+                    || address.isAnyLocalAddress()
+                    || isUniqueLocalIpv6(address);
+        } catch (UnknownHostException e) {
+            // Should not happen for an IP literal; treat as internal to fail safe.
+            return true;
+        }
+    }
+
+    /**
+     * Returns {@code true} only when {@code value} is a numeric IPv4 (dotted-quad) or IPv6 literal, so that
+     * {@link InetAddress#getByName(String)} resolves it locally without a DNS round-trip.
+     */
+    private static boolean isIpLiteral(String value) {
+        // IPv6 literals contain a colon; an IPv4 literal is digits-and-dots only.
+        if (value.indexOf(':') >= 0) {
+            return true;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            final char c = value.charAt(i);
+            if (c != '.' && (c < '0' || c > '9')) {
+                return false;
+            }
+        }
+        return value.indexOf('.') >= 0;
+    }
+
+    /** Returns {@code true} for IPv6 unique-local addresses ({@code fc00::/7}), which Java does not flag directly. */
+    private static boolean isUniqueLocalIpv6(InetAddress address) {
+        final byte[] bytes = address.getAddress();
+        return bytes.length == 16 && (bytes[0] & 0xFE) == 0xFC;
     }
 
     /**

--- a/src/main/java/org/jahia/community/modules/customgpt/util/Utils.java
+++ b/src/main/java/org/jahia/community/modules/customgpt/util/Utils.java
@@ -50,6 +50,9 @@ public final class Utils {
     public static Set<String> getPropertyValuesAsSet(JCRNodeWrapper node, String property) {
         final Set<String> result = new HashSet<>();
         try {
+            if (!node.hasProperty(property)) {
+                return result;
+            }
             final Value[] values = node.getProperty(property).getValues();
             for (Value value : values) {
                 result.add(value.getString());
@@ -74,6 +77,12 @@ public final class Utils {
         try {
             final String sitemapIndexURL = siteNode.getPropertyAsString("sitemapIndexURL");
             final URL serverUrl = URI.create(sitemapIndexURL).toURL();
+            // The rendering request built from this host carries Jahia Basic-auth credentials; reject a host that is a
+            // literal private/loopback/link-local IP so credentials cannot be sent to an internal SSRF target.
+            if (SecurityUtils.isInternalHost(serverUrl.getHost())) {
+                LOGGER.error("Refusing to render site {}: sitemapIndexURL host resolves to an internal/private address", siteNode.getPath());
+                return "";
+            }
             hostName = StringUtils.substringBeforeLast(sitemapIndexURL, serverUrl.getPath());
             return hostName;
         } catch (MalformedURLException | IllegalArgumentException e) {

--- a/src/main/resources/META-INF/configurations/org.jahia.community.modules.customgpt.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.community.modules.customgpt.cfg
@@ -1,6 +1,5 @@
 # default configuration - won't be overridden
 org.jahia.community.modules.customgpt.content.indexedMainResourceTypes=jnt:page,jmix:mainResource
-org.jahia.community.modules.customgpt.file.mappedNodetypes=jnt:file
 org.jahia.community.modules.customgpt.content.indexedSubNodeTypes=jmix:droppableContent
 org.jahia.community.modules.customgpt.content.indexedFileExtensions=pdf
 org.jahia.community.modules.customgpt.operations.batch.size=500

--- a/src/main/resources/javascript/apps/package.json
+++ b/src/main/resources/javascript/apps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/customgpt-ai",
-  "version": "1.0.3-SNAPSHOT",
+  "version": "1.0.7-SNAPSHOT",
   "scripts": {
     "build": "yarn webpack",
     "webpack": "webpack",
@@ -12,6 +12,8 @@
     "lint:js:fix": "yarn lint:js --fix",
     "lint": "yarn lint:js",
     "lint:fix": "yarn lint:js:fix",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
     "sync-pom": "sync-pom-version --use-yarn"
   },
   "description": "React admin UI for CustomGPT.ai settings",
@@ -39,7 +41,10 @@
     "ip-address": "^10.1.1",
     "js-yaml": "^4.1.1",
     "normalize-package-data": "^7.0.0",
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "strip-ansi": "^6.0.1",
+    "string-width": "^4.2.3",
+    "wrap-ansi": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",
@@ -49,6 +54,10 @@
     "@cyclonedx/webpack-plugin": "^5.3.2",
     "@jahia/eslint-config": "2.1.0",
     "@jahia/webpack-config": "^1.1.0",
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/react": "^14.2.0",
+    "@testing-library/user-event": "^14.5.0",
+    "babel-jest": "^29.7.0",
     "babel-loader": "^10.0.0",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^11.0.0",
@@ -58,6 +67,9 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "file-loader": "^6.2.0",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "rimraf": "^5.0.0",
     "sass": "^1.52.1",
     "sass-loader": "^12.4.0",

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -11,6 +11,7 @@
     "contentIndexedFileExtensionsPlaceholder": "pdf,docx",
     "commaSeparatedHint": "Kommagetrennte Liste",
     "operationsBatchSize": "Stapelgröße",
+    "operationsBatchSizeHint": "Ganzzahl zwischen 1 und 10000",
     "projectId": "Projekt-ID",
     "token": "API-Token",
     "apiBaseUrl": "API-Basis-URL",

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -30,6 +30,7 @@
     "saveSuccess": "Einstellungen erfolgreich gespeichert.",
     "saveError": "Fehler beim Speichern der Einstellungen.",
     "dangerZoneTitle": "Gefahrenbereich",
+    "loading": "Einstellungen werden geladen…",
     "purgeAllPages": "Alle Seiten löschen",
     "purgeConfirm": "Alle Seiten aus Ihrem CustomGPT-Projekt werden unwiderruflich gelöscht. Sind Sie sicher?",
     "purgeSuccess": "{{count}} Seite(n) erfolgreich aus CustomGPT gelöscht.",
@@ -37,6 +38,9 @@
     "purgeConfirmTitle": "Löschen bestätigen",
     "confirmPurge": "Ja, alles löschen",
     "cancel": "Abbrechen",
-    "requiredFieldsNote": "Mit * markierte Felder sind Pflichtfelder"
+    "requiredFieldsNote": "Mit * markierte Felder sind Pflichtfelder",
+    "validationProjectIdRequired": "Projekt-ID ist erforderlich.",
+    "validationTokenRequired": "API-Token ist erforderlich.",
+    "purging": "Wird gelöscht…"
   }
 }

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -11,6 +11,7 @@
     "contentIndexedFileExtensionsPlaceholder": "pdf,docx",
     "commaSeparatedHint": "Comma-separated list",
     "operationsBatchSize": "Batch Size",
+    "operationsBatchSizeHint": "Integer between 1 and 10000",
     "projectId": "Project ID",
     "token": "API Token",
     "apiBaseUrl": "API Base URL",

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -38,6 +38,9 @@
     "purgeConfirmTitle": "Confirm Purge",
     "confirmPurge": "Yes, Purge All",
     "cancel": "Cancel",
-    "requiredFieldsNote": "Fields marked with * are required"
+    "requiredFieldsNote": "Fields marked with * are required",
+    "validationProjectIdRequired": "Project ID is required.",
+    "validationTokenRequired": "API Token is required.",
+    "purging": "Purging…"
   }
 }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -30,6 +30,7 @@
     "saveSuccess": "Paramètres enregistrés avec succès.",
     "saveError": "Échec de l'enregistrement des paramètres.",
     "dangerZoneTitle": "Zone dangereuse",
+    "loading": "Chargement des paramètres…",
     "purgeAllPages": "Supprimer toutes les pages",
     "purgeConfirm": "Cette action supprimera définitivement toutes les pages de votre projet CustomGPT. Cette action est irréversible. Êtes-vous sûr ?",
     "purgeSuccess": "Suppression réussie de {{count}} page(s) de CustomGPT.",
@@ -37,6 +38,9 @@
     "purgeConfirmTitle": "Confirmer la suppression",
     "confirmPurge": "Oui, tout supprimer",
     "cancel": "Annuler",
-    "requiredFieldsNote": "Les champs marqués d'un * sont obligatoires"
+    "requiredFieldsNote": "Les champs marqués d'un * sont obligatoires",
+    "validationProjectIdRequired": "L'ID du projet est obligatoire.",
+    "validationTokenRequired": "Le jeton API est obligatoire.",
+    "purging": "Suppression en cours…"
   }
 }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -11,6 +11,7 @@
     "contentIndexedFileExtensionsPlaceholder": "pdf,docx",
     "commaSeparatedHint": "Liste séparée par des virgules",
     "operationsBatchSize": "Taille du lot",
+    "operationsBatchSizeHint": "Entier compris entre 1 et 10000",
     "projectId": "ID du projet",
     "token": "Jeton API",
     "apiBaseUrl": "URL de base de l'API",

--- a/src/test/java/org/jahia/community/modules/customgpt/indexer/IndexerDeduplicationTest.java
+++ b/src/test/java/org/jahia/community/modules/customgpt/indexer/IndexerDeduplicationTest.java
@@ -1,0 +1,226 @@
+package org.jahia.community.modules.customgpt.indexer;
+
+import java.util.Collection;
+import org.jahia.community.modules.customgpt.service.Service;
+import org.jahia.community.modules.customgpt.settings.Config;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for the path deduplication logic in {@link Indexer#addNodeToDelete} and
+ * {@link Indexer#isMarkedForRemoval}.
+ *
+ * No JCR, OSGi, or network dependencies are exercised.  The {@link Service} and {@link Config}
+ * dependencies are mocked; only the in-memory {@code TreeSet<String>} deduplication logic is
+ * exercised, which is purely deterministic.
+ */
+public class IndexerDeduplicationTest {
+
+    private Indexer indexer;
+
+    @Before
+    public void setUp() {
+        // Construct Indexer the same way production does: Service + Config mocks.
+        // init() is deliberately NOT called because it resolves JahiaUserManagerService (OSGi).
+        indexer = new Indexer(mock(Service.class), mock(Config.class));
+    }
+
+    // ---- isEmpty ----
+
+    @Test
+    public void isEmpty_trueWhenNothingQueued() {
+        assertThat(indexer.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void isEmpty_falseAfterAddNodeToDelete() {
+        indexer.addNodeToDelete("/sites/acme/home");
+        assertThat(indexer.isEmpty()).isFalse();
+    }
+
+    // ---- blank / null path ignored ----
+
+    // S5976: kept as separate cases — JUnit4 Parameterized cannot be scoped to one group
+    // inside this mixed test class without a risky Enclosed-runner restructure.
+    @SuppressWarnings("java:S5976")
+    @Test
+    public void addNodeToDelete_blankPathIsIgnored() {
+        indexer.addNodeToDelete("   ");
+        assertThat(indexer.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void addNodeToDelete_emptyPathIsIgnored() {
+        indexer.addNodeToDelete("");
+        assertThat(indexer.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void addNodeToDelete_nullPathIsIgnored() {
+        indexer.addNodeToDelete(null);
+        assertThat(indexer.isEmpty()).isTrue();
+    }
+
+    // ---- ancestor wins: descendant dropped ----
+
+    @Test
+    public void addNodeToDelete_ancestorAddedFirst_descendantIsDropped() {
+        // Arrange
+        final String ancestor = "/sites/acme/home";
+        final String descendant = "/sites/acme/home/about";
+
+        // Act
+        indexer.addNodeToDelete(ancestor);
+        indexer.addNodeToDelete(descendant);
+
+        // Assert: only the ancestor is retained
+        final Collection<String> toRemove = indexer.getNodePathsToRemove();
+        assertThat(toRemove).containsExactly(ancestor);
+    }
+
+    @Test
+    public void addNodeToDelete_deepDescendant_ancestorAlreadyPresent_dropped() {
+        final String ancestor = "/sites/acme";
+        indexer.addNodeToDelete(ancestor);
+        indexer.addNodeToDelete("/sites/acme/home/about/team");
+
+        assertThat(indexer.getNodePathsToRemove()).containsExactly(ancestor);
+    }
+
+    // ---- ancestor wins: existing descendants replaced ----
+
+    @Test
+    public void addNodeToDelete_ancestorAddedLast_existingDescendantsPruned() {
+        // Arrange: add two descendants first
+        final String d1 = "/sites/acme/home/about";
+        final String d2 = "/sites/acme/home/contact";
+        final String ancestor = "/sites/acme/home";
+
+        indexer.addNodeToDelete(d1);
+        indexer.addNodeToDelete(d2);
+
+        // Act: add the ancestor — both descendants should be removed
+        indexer.addNodeToDelete(ancestor);
+
+        // Assert
+        assertThat(indexer.getNodePathsToRemove()).containsExactly(ancestor);
+    }
+
+    @Test
+    public void addNodeToDelete_multipleDescendantsPrunedByAncestor() {
+        // Arrange: three descendants at different depths
+        indexer.addNodeToDelete("/sites/acme/home/a");
+        indexer.addNodeToDelete("/sites/acme/home/a/b");
+        indexer.addNodeToDelete("/sites/acme/home/c");
+
+        // Act
+        indexer.addNodeToDelete("/sites/acme/home");
+
+        // Assert: only the ancestor
+        assertThat(indexer.getNodePathsToRemove()).containsExactly("/sites/acme/home");
+    }
+
+    // ---- sibling paths are both kept ----
+
+    @Test
+    public void addNodeToDelete_siblingsAreKeptSeparately() {
+        final String p1 = "/sites/acme/home";
+        final String p2 = "/sites/acme/news";
+
+        indexer.addNodeToDelete(p1);
+        indexer.addNodeToDelete(p2);
+
+        assertThat(indexer.getNodePathsToRemove()).containsExactlyInAnyOrder(p1, p2);
+    }
+
+    // ---- prefix collision guard: path that is a string-prefix but not an ancestor ----
+
+    @Test
+    public void addNodeToDelete_stringPrefixButNotAncestor_bothKept() {
+        // "/sites/acmefoo" starts with "/sites/acme" but is NOT a descendant of "/sites/acme"
+        // because the delimiter "/" is absent immediately after "acme".
+        final String p1 = "/sites/acme";
+        final String p2 = "/sites/acmefoo";
+
+        indexer.addNodeToDelete(p1);
+        indexer.addNodeToDelete(p2);
+
+        assertThat(indexer.getNodePathsToRemove()).containsExactlyInAnyOrder(p1, p2);
+    }
+
+    // ---- idempotent: same path added twice ----
+
+    @Test
+    public void addNodeToDelete_samePathTwiceResultsInSingleEntry() {
+        indexer.addNodeToDelete("/sites/acme/home");
+        indexer.addNodeToDelete("/sites/acme/home");
+
+        assertThat(indexer.getNodePathsToRemove()).hasSize(1);
+    }
+
+    // ---- customGptPageId tracking ----
+
+    @Test
+    public void addNodeToDelete_withCustomGptPageId_tracksPageId() {
+        indexer.addNodeToDelete("page-42", "/sites/acme/home");
+
+        assertThat(indexer.getCustomGptPageToRemove()).containsExactly("page-42");
+        assertThat(indexer.getNodePathsToRemove()).containsExactly("/sites/acme/home");
+    }
+
+    @Test
+    public void addNodeToDelete_nullPageId_onlyPathTracked() {
+        indexer.addNodeToDelete(null, "/sites/acme/home");
+
+        assertThat(indexer.getCustomGptPageToRemove()).isEmpty();
+        assertThat(indexer.getNodePathsToRemove()).containsExactly("/sites/acme/home");
+    }
+
+    // ---- isMarkedForRemoval ----
+
+    @Test
+    public void isMarkedForRemoval_exactMatch_returnsTrue() {
+        indexer.addNodeToDelete("/sites/acme/home");
+
+        assertThat(indexer.isMarkedForRemoval("/sites/acme/home")).isTrue();
+    }
+
+    @Test
+    public void isMarkedForRemoval_descendantOfMarkedPath_returnsTrue() {
+        indexer.addNodeToDelete("/sites/acme/home");
+
+        assertThat(indexer.isMarkedForRemoval("/sites/acme/home/about")).isTrue();
+        assertThat(indexer.isMarkedForRemoval("/sites/acme/home/about/team")).isTrue();
+    }
+
+    @Test
+    public void isMarkedForRemoval_ancestorOfMarkedPath_returnsFalse() {
+        indexer.addNodeToDelete("/sites/acme/home");
+
+        assertThat(indexer.isMarkedForRemoval("/sites/acme")).isFalse();
+        assertThat(indexer.isMarkedForRemoval("/sites")).isFalse();
+    }
+
+    @Test
+    public void isMarkedForRemoval_unrelatedPath_returnsFalse() {
+        indexer.addNodeToDelete("/sites/acme/home");
+
+        assertThat(indexer.isMarkedForRemoval("/sites/other/page")).isFalse();
+    }
+
+    @Test
+    public void isMarkedForRemoval_stringPrefixButNotDescendant_returnsFalse() {
+        // "/sites/acme" is marked; "/sites/acmefoo" must NOT be considered a descendant
+        indexer.addNodeToDelete("/sites/acme");
+
+        assertThat(indexer.isMarkedForRemoval("/sites/acmefoo")).isFalse();
+    }
+
+    @Test
+    public void isMarkedForRemoval_emptySet_returnsFalse() {
+        assertThat(indexer.isMarkedForRemoval("/sites/acme/home")).isFalse();
+    }
+}

--- a/src/test/java/org/jahia/community/modules/customgpt/service/ServiceAcceptablePathTest.java
+++ b/src/test/java/org/jahia/community/modules/customgpt/service/ServiceAcceptablePathTest.java
@@ -1,0 +1,100 @@
+package org.jahia.community.modules.customgpt.service;
+
+import java.lang.reflect.Method;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the {@code acceptablePathToIndex} predicate in {@link Service}.
+ *
+ * <p>The method is {@code public} and depends only on string operations (no JCR, no OSGi).
+ * We exercise it via reflection rather than constructing a full {@code Service} (which requires
+ * a live OSGi container with all {@code @Reference} dependencies satisfied).
+ *
+ * <p>The predicate returns {@code true} when:
+ * <ul>
+ *   <li>the path starts with {@code /sites/} (matching the internal SITE_MATCHER regex)
+ *       or {@code /trash-}, AND</li>
+ *   <li>the path does not end with {@code customGptPageId}, AND</li>
+ *   <li>the path does not end with {@code jcr:lastModified}.</li>
+ * </ul>
+ */
+public class ServiceAcceptablePathTest {
+
+    /**
+     * Invokes {@code Service.acceptablePathToIndex} on a bare (null-field) Service instance.
+     * The method uses only its parameter and static final fields — no injected dependencies.
+     */
+    private boolean acceptable(String path) throws Exception {
+        // Construct without triggering @Activate
+        final Service service = newBareService();
+        final Method m = Service.class.getDeclaredMethod("acceptablePathToIndex", String.class);
+        m.setAccessible(true);
+        return (boolean) m.invoke(service, path);
+    }
+
+    private static Service newBareService() throws Exception {
+        // Use unsafe/objenesis-style construction to bypass the constructor if needed.
+        // Actually Service has a default no-arg constructor (compiler-generated); OSGi
+        // lifecycle methods (@Activate) are not called here.
+        return Service.class.getDeclaredConstructor().newInstance();
+    }
+
+    // ---- /sites/ paths ----
+
+    @Test
+    public void acceptablePathToIndex_sitesPath_returnsTrue() throws Exception {
+        assertThat(acceptable("/sites/acme/home")).isTrue();
+    }
+
+    @Test
+    public void acceptablePathToIndex_deepSitesPath_returnsTrue() throws Exception {
+        assertThat(acceptable("/sites/acme/home/about/team")).isTrue();
+    }
+
+    @Test
+    public void acceptablePathToIndex_sitesRootSuffixOnly_returnsFalse() throws Exception {
+        // "/sites" without a trailing slash does NOT match the "/sites/.+" regex
+        assertThat(acceptable("/sites")).isFalse();
+    }
+
+    @Test
+    public void acceptablePathToIndex_sitesSuffix_pathEndingWithCustomGptPageId_returnsFalse() throws Exception {
+        assertThat(acceptable("/sites/acme/home/customGptPageId")).isFalse();
+    }
+
+    @Test
+    public void acceptablePathToIndex_sitesSuffix_pathEndingWithJcrLastModified_returnsFalse() throws Exception {
+        assertThat(acceptable("/sites/acme/home/jcr:lastModified")).isFalse();
+    }
+
+    // ---- /trash- paths ----
+
+    @Test
+    public void acceptablePathToIndex_trashPath_returnsTrue() throws Exception {
+        assertThat(acceptable("/trash-acme/home")).isTrue();
+    }
+
+    @Test
+    public void acceptablePathToIndex_trashPath_endingWithCustomGptPageId_returnsFalse() throws Exception {
+        assertThat(acceptable("/trash-acme/customGptPageId")).isFalse();
+    }
+
+    // ---- unrelated paths ----
+
+    @Test
+    public void acceptablePathToIndex_modulesPath_returnsFalse() throws Exception {
+        assertThat(acceptable("/modules/customgpt-ai/node")).isFalse();
+    }
+
+    @Test
+    public void acceptablePathToIndex_usersPath_returnsFalse() throws Exception {
+        assertThat(acceptable("/users/root")).isFalse();
+    }
+
+    @Test
+    public void acceptablePathToIndex_emptyPath_returnsFalse() throws Exception {
+        assertThat(acceptable("")).isFalse();
+    }
+}

--- a/src/test/java/org/jahia/community/modules/customgpt/settings/ConfigParseTest.java
+++ b/src/test/java/org/jahia/community/modules/customgpt/settings/ConfigParseTest.java
@@ -1,0 +1,345 @@
+package org.jahia.community.modules.customgpt.settings;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the pure parsing / coercion helpers in {@link Config}.
+ *
+ * <p>Paths that call {@code NodeTypeRegistry.getInstance()} (i.e. {@code splitNodeTypeByComma}
+ * via {@code PROP_CONTENT_INDEXED_MAIN_RESOURCE_TYPES} and {@code PROP_CONTENT_INDEXED_SUB_NODE_TYPES})
+ * are skipped because NodeTypeRegistry is OSGi-bound and unavailable outside a container.
+ * Those keys are simply left out of the test dictionary so the split returns an empty set without
+ * reaching the registry.
+ *
+ * <p>The {@code FrameworkService.sendEvent} call inside {@link Config#updated} is also OSGi-bound.
+ * Tests that exercise property coercions therefore assert on the getter values directly and do not
+ * rely on the event side-effect.
+ */
+public class ConfigParseTest {
+
+    private static final String NS = "org.jahia.community.modules.customgpt";
+
+    // Property keys as used in Config
+    private static final String KEY_BATCH_SIZE    = NS + ".operations.batch.size";
+    private static final String KEY_SCHEDULE_ASAP = NS + ".scheduleJobASAP";
+    private static final String KEY_DRY_RUN       = NS + ".dryRun";
+    private static final String KEY_FILE_EXT      = NS + ".content.indexedFileExtensions";
+    private static final String KEY_API_BASE_URL  = NS + ".apiBaseUrl";
+    private static final String KEY_RATE_LIMIT    = NS + ".rateLimit.requestsPerSecond";
+    private static final String KEY_PROJECT_ID    = NS + ".projectId";
+    private static final String KEY_TOKEN         = NS + ".token";
+    private static final String KEY_USERNAME      = NS + ".jahia.username";
+    private static final String KEY_PASSWORD      = NS + ".jahia.password";
+    private static final String KEY_COOKIE_NAME   = NS + ".jahia.serverCookie.name";
+    private static final String KEY_COOKIE_VALUE  = NS + ".jahia.serverCookie.value";
+    private static final String KEY_COOKIE_DOMAIN = NS + ".jahia.serverCookie.domain";
+
+    // Main-resource and sub-node keys must be absent so splitNodeTypeByComma is never called
+    // (it would hit NodeTypeRegistry which is not available outside OSGi).
+
+    private Config config;
+
+    @Before
+    public void setUp() {
+        config = new Config();
+    }
+
+    // ---- NotConfiguredException before updated() ----
+
+    @Test
+    public void getBulkOperationsBatchSize_throwsWhenNotConfigured() {
+        assertThatThrownBy(() -> config.getBulkOperationsBatchSize())
+                .isInstanceOf(NotConfiguredException.class);
+    }
+
+    @Test
+    public void getContentIndexedMainResources_throwsWhenNotConfigured() {
+        assertThatThrownBy(() -> config.getContentIndexedMainResources())
+                .isInstanceOf(NotConfiguredException.class);
+    }
+
+    @Test
+    public void getContentIndexedSubNodes_throwsWhenNotConfigured() {
+        assertThatThrownBy(() -> config.getContentIndexedSubNodes())
+                .isInstanceOf(NotConfiguredException.class);
+    }
+
+    // ---- getInt coercions ----
+
+    @Test
+    public void getInt_parsesNumberInstanceDirectly() throws NotConfiguredException {
+        // Arrange: value is an Integer (as OSGi ConfigAdmin delivers typed properties)
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_BATCH_SIZE, 42);
+
+        // Act
+        callUpdated(props);
+
+        // Assert
+        assertThat(config.getBulkOperationsBatchSize()).isEqualTo(42);
+    }
+
+    @Test
+    public void getInt_parsesStringRepresentation() throws NotConfiguredException {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_BATCH_SIZE, "77");
+
+        callUpdated(props);
+
+        assertThat(config.getBulkOperationsBatchSize()).isEqualTo(77);
+    }
+
+    @Test
+    public void getInt_returnsDefaultWhenKeyAbsent() throws NotConfiguredException {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.remove(KEY_BATCH_SIZE);
+
+        callUpdated(props);
+
+        // Default is 500 as declared in Config
+        assertThat(config.getBulkOperationsBatchSize()).isEqualTo(500);
+    }
+
+    @Test
+    public void getInt_parsesLongAsNumber() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_RATE_LIMIT, 15L); // Long implements Number
+
+        callUpdated(props);
+
+        assertThat(config.getRateLimitRequestsPerSecond()).isEqualTo(15);
+    }
+
+    // ---- getBoolean coercions ----
+
+    @Test
+    public void getBoolean_parsesNativeBooleanTrue() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_DRY_RUN, Boolean.TRUE);
+
+        callUpdated(props);
+
+        assertThat(config.isDryRun()).isTrue();
+    }
+
+    @Test
+    public void getBoolean_parsesStringTrue() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_DRY_RUN, "true");
+
+        callUpdated(props);
+
+        assertThat(config.isDryRun()).isTrue();
+    }
+
+    @Test
+    public void getBoolean_parsesStringFalse() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_DRY_RUN, "false");
+
+        callUpdated(props);
+
+        assertThat(config.isDryRun()).isFalse();
+    }
+
+    @Test
+    public void getBoolean_returnsDefaultFalseWhenKeyAbsent() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.remove(KEY_DRY_RUN);
+        props.remove(KEY_SCHEDULE_ASAP);
+
+        callUpdated(props);
+
+        assertThat(config.isDryRun()).isFalse();
+        assertThat(config.isScheduleJobASAP()).isFalse();
+    }
+
+    // ---- getString coercions ----
+
+    @Test
+    public void getString_returnsValueWhenPresent() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_PROJECT_ID, "proj-99");
+        props.put(KEY_TOKEN, "tok-abc");
+
+        callUpdated(props);
+
+        assertThat(config.getCustomGptProjectId()).isEqualTo("proj-99");
+        assertThat(config.getCustomGptToken()).isEqualTo("tok-abc");
+    }
+
+    @Test
+    public void getString_returnsEmptyStringDefaultWhenKeyAbsent() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.remove(KEY_PROJECT_ID);
+        props.remove(KEY_TOKEN);
+
+        callUpdated(props);
+
+        assertThat(config.getCustomGptProjectId()).isEmpty();
+        assertThat(config.getCustomGptToken()).isEmpty();
+    }
+
+    // ---- indexedFileExtensions ----
+
+    @Test
+    public void indexedFileExtensions_emptyStringYieldsEmptySet() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_FILE_EXT, "");
+
+        callUpdated(props);
+
+        assertThat(config.getIndexedFileExtensions()).isEmpty();
+    }
+
+    @Test
+    public void indexedFileExtensions_nullYieldsEmptySet() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.remove(KEY_FILE_EXT); // absent → treated as null
+
+        callUpdated(props);
+
+        assertThat(config.getIndexedFileExtensions()).isEmpty();
+    }
+
+    @Test
+    public void indexedFileExtensions_csvWithSpacesIsTrimmedCorrectly() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_FILE_EXT, " pdf , docx , xlsx ");
+
+        callUpdated(props);
+
+        final Set<String> exts = config.getIndexedFileExtensions();
+        assertThat(exts).containsExactlyInAnyOrder("pdf", "docx", "xlsx");
+    }
+
+    @Test
+    public void indexedFileExtensions_singleExtensionWithNoComma() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_FILE_EXT, "pdf");
+
+        callUpdated(props);
+
+        assertThat(config.getIndexedFileExtensions()).containsExactly("pdf");
+    }
+
+    @Test
+    public void indexedFileExtensions_trailingCommaIsIgnored() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_FILE_EXT, "pdf,docx,");
+
+        callUpdated(props);
+
+        assertThat(config.getIndexedFileExtensions()).containsExactlyInAnyOrder("pdf", "docx");
+    }
+
+    // ---- apiBaseUrl SSRF / https validation ----
+
+    // S5976: kept as separate cases — JUnit4 Parameterized cannot be scoped to one group
+    // inside this mixed test class without a risky Enclosed-runner restructure.
+    @SuppressWarnings("java:S5976")
+    @Test
+    public void updated_rejectsHttpApiBaseUrl_leavesConfigured_false() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_API_BASE_URL, "http://app.customgpt.ai/api/v1");
+
+        callUpdated(props);
+
+        // Config must NOT be marked configured when base URL is not https
+        assertThat(config.isConfigured()).isFalse();
+    }
+
+    @Test
+    public void updated_rejectsInternalIpApiBaseUrl_leavesConfigured_false() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_API_BASE_URL, "https://192.168.1.1/api/v1");
+
+        callUpdated(props);
+
+        assertThat(config.isConfigured()).isFalse();
+    }
+
+    @Test
+    public void updated_rejectsLoopbackApiBaseUrl_leavesConfigured_false() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_API_BASE_URL, "https://127.0.0.1/api/v1");
+
+        callUpdated(props);
+
+        assertThat(config.isConfigured()).isFalse();
+    }
+
+    @Test
+    public void updated_rejectsLinkLocalApiBaseUrl_leavesConfigured_false() {
+        final Dictionary<String, Object> props = minimalValidProps();
+        props.put(KEY_API_BASE_URL, "https://169.254.169.254/latest/meta-data/");
+
+        callUpdated(props);
+
+        assertThat(config.isConfigured()).isFalse();
+    }
+
+    @Test
+    public void updated_nullPropertiesIsIgnored_remainsNotConfigured() throws Exception {
+        // updated(null) is a no-op per spec
+        config.updated(null);
+
+        assertThat(config.isConfigured()).isFalse();
+    }
+
+    // ---- isConfigured after valid update -- only asserts the flag, not OSGi event ----
+
+    @Test
+    public void isConfigured_trueAfterValidHttpsUrl() {
+        callUpdated(minimalValidProps());
+        assertThat(config.isConfigured()).isTrue();
+    }
+
+    // ---- helpers ----
+
+    /**
+     * Minimal dictionary that passes the https validation gate (so {@code configured} is set)
+     * without supplying node-type keys that would trigger NodeTypeRegistry lookups.
+     */
+    private static Dictionary<String, Object> minimalValidProps() {
+        final Dictionary<String, Object> d = new Hashtable<>();
+        d.put(KEY_API_BASE_URL, "https://app.customgpt.ai/api/v1");
+        d.put(KEY_BATCH_SIZE, 500);
+        d.put(KEY_RATE_LIMIT, 10);
+        d.put(KEY_PROJECT_ID, "");
+        d.put(KEY_TOKEN, "");
+        d.put(KEY_USERNAME, "");
+        d.put(KEY_PASSWORD, "");
+        d.put(KEY_COOKIE_NAME, "");
+        d.put(KEY_COOKIE_VALUE, "");
+        d.put(KEY_COOKIE_DOMAIN, "");
+        return d;
+    }
+
+    /**
+     * Calls {@link Config#updated(Dictionary)} but silently swallows the
+     * {@link org.osgi.service.cm.ConfigurationException} (the method signature declares it but
+     * Config's implementation never actually throws it).
+     * The {@code FrameworkService.sendEvent} call inside Config is an OSGi static call that will
+     * throw a NullPointerException when the bundle context is absent; we catch and ignore it here
+     * because the property-coercion logic runs before the event dispatch, which is what we test.
+     */
+    private void callUpdated(Dictionary<String, Object> props) {
+        try {
+            config.updated(props);
+        } catch (org.osgi.service.cm.ConfigurationException e) {
+            throw new RuntimeException("Unexpected ConfigurationException", e);
+        } catch (Exception e) {
+            // FrameworkService.sendEvent throws NullPointerException outside OSGi —
+            // ignore it; the coercion and configured-flag logic already ran.
+            // Only absorb if config was actually processed (non-null props).
+        }
+    }
+}

--- a/src/test/java/org/jahia/community/modules/customgpt/util/RateLimitInterceptorTest.java
+++ b/src/test/java/org/jahia/community/modules/customgpt/util/RateLimitInterceptorTest.java
@@ -1,0 +1,296 @@
+package org.jahia.community.modules.customgpt.util;
+
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link RateLimitInterceptor}.
+ *
+ * Timing-sensitive paths (acquireToken waits) are avoided: the test suite asserts on
+ * {@code computeBackoffMs} return-value ranges and on chain.proceed call-counts only.
+ * The rate-limit bucket is seeded with capacity = 100 rps so the first token is always
+ * available instantly.  Retry-After headers with value "0" keep sleep durations to 0 ms,
+ * making retry-loop tests near-instant.
+ *
+ * All {@link Response} objects built in this file carry an empty body (required by OkHttp 4
+ * to make the response closeable).
+ */
+public class RateLimitInterceptorTest {
+
+    // ---- constructor validation ----
+
+    @Test
+    public void constructor_rejectsZeroRequestsPerSecond() {
+        assertThatThrownBy(() -> new RateLimitInterceptor(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("requestsPerSecond must be > 0");
+    }
+
+    @Test
+    public void constructor_rejectsNegativeRequestsPerSecond() {
+        assertThatThrownBy(() -> new RateLimitInterceptor(-5))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("requestsPerSecond must be > 0");
+    }
+
+    @Test
+    public void constructor_acceptsPositiveRequestsPerSecond() {
+        // Constructing with any positive rps must not throw and must yield a usable instance.
+        assertThatCode(() -> {
+            assertThat(new RateLimitInterceptor(1)).isNotNull();
+            assertThat(new RateLimitInterceptor(10)).isNotNull();
+            assertThat(new RateLimitInterceptor(100)).isNotNull();
+        }).doesNotThrowAnyException();
+    }
+
+    // ---- computeBackoffMs: numeric Retry-After ----
+
+    @Test
+    public void computeBackoffMs_numericRetryAfterIsConvertedToMilliseconds() throws Exception {
+        // Arrange
+        final RateLimitInterceptor interceptor = new RateLimitInterceptor(100);
+        final Response response = buildResponse(429, null, "3");
+
+        // Act — computeBackoffMs is private; reflective access is the only way to test it
+        // directly (same-package visibility is insufficient for private methods)
+        final long backoffMs = invokeComputeBackoffMs(interceptor, response, 1);
+
+        // Assert: 3 seconds * 1000 = 3000 ms
+        assertThat(backoffMs).isEqualTo(3_000L);
+    }
+
+    @Test
+    public void computeBackoffMs_numericRetryAfterWithLeadingWhitespace() throws Exception {
+        final RateLimitInterceptor interceptor = new RateLimitInterceptor(100);
+        final Response response = buildResponse(429, null, "  5  ");
+
+        final long backoffMs = invokeComputeBackoffMs(interceptor, response, 1);
+
+        assertThat(backoffMs).isEqualTo(5_000L);
+    }
+
+    // ---- computeBackoffMs: date-string Retry-After (falls back to exponential back-off) ----
+
+    // S5976: kept as separate cases — each asserts a distinct per-attempt back-off cap and
+    // uses reflection; a JUnit4 Parameterized group cannot be scoped here without a risky
+    // Enclosed-runner restructure of this mixed test class.
+    @SuppressWarnings("java:S5976")
+    @Test
+    public void computeBackoffMs_dateStringRetryAfterFallsBackToBoundedExponential_attempt1()
+            throws Exception {
+        final RateLimitInterceptor interceptor = new RateLimitInterceptor(100);
+        // An HTTP-date is not a number — triggers the exponential fallback
+        final Response response = buildResponse(429, null, "Thu, 01 Jan 2099 00:00:00 GMT");
+
+        final long backoffMs = invokeComputeBackoffMs(interceptor, response, 1);
+
+        // attempt=1 → cap = min(30000, 1000 << 0) = 1000; result in [0, 1000]
+        assertThat(backoffMs).isBetween(0L, 1_000L);
+    }
+
+    @Test
+    public void computeBackoffMs_dateStringRetryAfterFallsBackToBoundedExponential_attempt2()
+            throws Exception {
+        final RateLimitInterceptor interceptor = new RateLimitInterceptor(100);
+        final Response response = buildResponse(429, null, "not-a-number");
+
+        final long backoffMs = invokeComputeBackoffMs(interceptor, response, 2);
+
+        // attempt=2 → cap = min(30000, 1000 << 1) = 2000; result in [0, 2000]
+        assertThat(backoffMs).isBetween(0L, 2_000L);
+    }
+
+    @Test
+    public void computeBackoffMs_dateStringRetryAfterFallsBackToBoundedExponential_attempt3()
+            throws Exception {
+        final RateLimitInterceptor interceptor = new RateLimitInterceptor(100);
+        final Response response = buildResponse(429, null, "not-a-number");
+
+        final long backoffMs = invokeComputeBackoffMs(interceptor, response, 3);
+
+        // attempt=3 → cap = min(30000, 1000 << 2) = 4000; result in [0, 4000]
+        assertThat(backoffMs).isBetween(0L, 4_000L);
+    }
+
+    @Test
+    public void computeBackoffMs_noRetryAfterHeaderUsesExponentialBackoff() throws Exception {
+        final RateLimitInterceptor interceptor = new RateLimitInterceptor(100);
+        // Response with no Retry-After header
+        final Response response = buildResponse(429, null, null);
+
+        final long backoffMs = invokeComputeBackoffMs(interceptor, response, 1);
+
+        assertThat(backoffMs).isBetween(0L, 1_000L);
+    }
+
+    @Test
+    public void computeBackoffMs_maxBackoffCapIsRespected() throws Exception {
+        // At very high attempt numbers the cap must never exceed MAX_BACKOFF_MS (30 000 ms).
+        final RateLimitInterceptor interceptor = new RateLimitInterceptor(100);
+        final Response response = buildResponse(429, null, "not-a-number");
+
+        // attempt=20 → 1000 << 19 would overflow but Math.min(30000, ...) caps it
+        final long backoffMs = invokeComputeBackoffMs(interceptor, response, 20);
+
+        assertThat(backoffMs).isBetween(0L, 30_000L);
+    }
+
+    // ---- 429-retry loop via mocked Chain ----
+
+    @Test
+    public void intercept_retriesOn429ThenReturns200() throws Exception {
+        // Arrange: 2 × 429 then 1 × 200; Retry-After: 0 keeps back-off sleep to 0 ms
+        final RateLimitInterceptor interceptor = new RateLimitInterceptor(100);
+        final Interceptor.Chain chain = mock(Interceptor.Chain.class);
+        final Request request = dummyRequest();
+
+        when(chain.request()).thenReturn(request);
+        when(chain.proceed(request))
+                .thenReturn(buildResponse(429, request, "0"))
+                .thenReturn(buildResponse(429, request, "0"))
+                .thenReturn(buildResponse(200, request, null));
+
+        // Act
+        final Response result = interceptor.intercept(chain);
+
+        // Assert: initial call + 2 retries = 3 total
+        verify(chain, times(3)).proceed(request);
+        assertThat(result.code()).isEqualTo(200);
+    }
+
+    @Test
+    public void intercept_stopsAfterMaxRetriesAndReturnsLast429() throws Exception {
+        // Arrange: all 4 calls (initial + MAX_RETRIES=3) return 429 with Retry-After: 0
+        final RateLimitInterceptor interceptor = new RateLimitInterceptor(100);
+        final Interceptor.Chain chain = mock(Interceptor.Chain.class);
+        final Request request = dummyRequest();
+
+        when(chain.request()).thenReturn(request);
+        when(chain.proceed(request))
+                .thenReturn(buildResponse(429, request, "0"))
+                .thenReturn(buildResponse(429, request, "0"))
+                .thenReturn(buildResponse(429, request, "0"))
+                .thenReturn(buildResponse(429, request, "0"));
+
+        // Act
+        final Response result = interceptor.intercept(chain);
+
+        // Assert: initial + MAX_RETRIES(3) = 4 total calls; last 429 is returned
+        verify(chain, times(4)).proceed(request);
+        assertThat(result.code()).isEqualTo(429);
+    }
+
+    @Test
+    public void intercept_returnsImmediatelyOn200WithSingleProceedCall() throws Exception {
+        final RateLimitInterceptor interceptor = new RateLimitInterceptor(100);
+        final Interceptor.Chain chain = mock(Interceptor.Chain.class);
+        final Request request = dummyRequest();
+
+        when(chain.request()).thenReturn(request);
+        when(chain.proceed(request)).thenReturn(buildResponse(200, request, null));
+
+        final Response result = interceptor.intercept(chain);
+
+        // Only one proceed call — no retries needed
+        verify(chain, times(1)).proceed(request);
+        assertThat(result.code()).isEqualTo(200);
+    }
+
+    // ---- InterruptedException path ----
+
+    @Test
+    public void intercept_setsInterruptFlagWhenInterruptedDuringBackoff() throws Exception {
+        // Strategy: pre-interrupt the thread; the retry back-off calls Thread.sleep(0ms from
+        // Retry-After:0) which surfaces the interrupt immediately as InterruptedException.
+        // The interceptor re-throws it as IOException("Rate limit back-off interrupted") and
+        // re-sets the interrupt flag.
+        final RateLimitInterceptor interceptor = new RateLimitInterceptor(100);
+        final Interceptor.Chain chain = mock(Interceptor.Chain.class);
+        final Request request = dummyRequest();
+
+        when(chain.request()).thenReturn(request);
+        // Return 429 so the retry loop tries to sleep — that sleep will surface the interrupt.
+        when(chain.proceed(request))
+                .thenReturn(buildResponse(429, request, "0"));
+
+        // Pre-interrupt this thread so the very first back-off sleep throws immediately
+        Thread.currentThread().interrupt();
+
+        boolean ioExceptionThrown = false;
+        try {
+            interceptor.intercept(chain);
+        } catch (IOException e) {
+            ioExceptionThrown = true;
+            // The interceptor must have restored the interrupt flag before rethrowing
+            assertThat(Thread.currentThread().isInterrupted())
+                    .as("interrupt flag must be set after IOException from back-off interruption")
+                    .isTrue();
+            assertThat(e.getMessage())
+                    .as("exception message should mention interruption")
+                    .containsIgnoringCase("interrupt");
+        } finally {
+            // Always clear the interrupt flag so subsequent tests are not affected
+            Thread.interrupted();
+        }
+
+        assertThat(ioExceptionThrown)
+                .as("intercept() should have thrown IOException when interrupted during back-off")
+                .isTrue();
+    }
+
+    // ---- helpers ----
+
+    private static Request dummyRequest() {
+        return new Request.Builder()
+                .url("https://app.customgpt.ai/api/v1/test")
+                .build();
+    }
+
+    /**
+     * Builds an OkHttp {@link Response} with an empty body so that {@code response.close()}
+     * does not throw.  OkHttp 4 requires a non-null body to close; a response without a body
+     * (built without {@code body(...)} call) is "not eligible for a body" and throws
+     * {@link IllegalStateException} on {@code close()}.
+     */
+    private static Response buildResponse(int code, Request request, String retryAfter) {
+        final Request req = request != null ? request : dummyRequest();
+        final String message = code == 200 ? "OK" : "Too Many Requests";
+        final Response.Builder builder = new Response.Builder()
+                .request(req)
+                .protocol(Protocol.HTTP_1_1)
+                .code(code)
+                .message(message)
+                .body(ResponseBody.create("", MediaType.get("application/json")));
+        if (retryAfter != null) {
+            builder.header("Retry-After", retryAfter);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Reflectively invokes the private {@code computeBackoffMs(Response, int)} method.
+     * This is the only use of reflection in this suite; it is required because the method
+     * is private and the contract (returned long value) is what we assert on.
+     */
+    private static long invokeComputeBackoffMs(RateLimitInterceptor interceptor,
+            Response response, int attempt) throws Exception {
+        final java.lang.reflect.Method m = RateLimitInterceptor.class
+                .getDeclaredMethod("computeBackoffMs", Response.class, int.class);
+        m.setAccessible(true);
+        return (long) m.invoke(interceptor, response, attempt);
+    }
+}

--- a/src/test/java/org/jahia/community/modules/customgpt/util/SecurityUtilsAdditionalTest.java
+++ b/src/test/java/org/jahia/community/modules/customgpt/util/SecurityUtilsAdditionalTest.java
@@ -1,0 +1,195 @@
+package org.jahia.community.modules.customgpt.util;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Additional unit tests for {@link SecurityUtils} focussing on the SSRF guard
+ * ({@link SecurityUtils#isInternalHost} and the IP-literal ranges rejected by
+ * {@link SecurityUtils#isHttpsUrl}), plus the masked-placeholder substring-not-equals case
+ * and dangerous URI schemes.
+ *
+ * The existing {@link SecurityUtilsTest} is left intact; these cases are added here so that
+ * each file remains focused and below the 400-line guideline.
+ */
+public class SecurityUtilsAdditionalTest {
+
+    // ---- isInternalHost: loopback ----
+
+    @Test
+    public void isInternalHost_loopbackIpv4_returnsTrue() {
+        assertThat(SecurityUtils.isInternalHost("127.0.0.1")).isTrue();
+    }
+
+    @Test
+    public void isInternalHost_loopbackIpv4_allOnes_returnsTrue() {
+        assertThat(SecurityUtils.isInternalHost("127.255.255.255")).isTrue();
+    }
+
+    @Test
+    public void isInternalHost_loopbackIpv6_returnsTrue() {
+        assertThat(SecurityUtils.isInternalHost("::1")).isTrue();
+    }
+
+    @Test
+    public void isInternalHost_loopbackIpv6_bracketed_returnsTrue() {
+        // URI parser wraps IPv6 in brackets; isInternalHost must strip them
+        assertThat(SecurityUtils.isInternalHost("[::1]")).isTrue();
+    }
+
+    // ---- isInternalHost: site-local (RFC 1918) ----
+
+    @Test
+    public void isInternalHost_rfc1918_10Block_returnsTrue() {
+        assertThat(SecurityUtils.isInternalHost("10.0.0.1")).isTrue();
+        assertThat(SecurityUtils.isInternalHost("10.255.255.254")).isTrue();
+    }
+
+    @Test
+    public void isInternalHost_rfc1918_172_16Block_returnsTrue() {
+        assertThat(SecurityUtils.isInternalHost("172.16.0.1")).isTrue();
+        assertThat(SecurityUtils.isInternalHost("172.31.255.254")).isTrue();
+    }
+
+    @Test
+    public void isInternalHost_rfc1918_192_168Block_returnsTrue() {
+        assertThat(SecurityUtils.isInternalHost("192.168.1.1")).isTrue();
+        assertThat(SecurityUtils.isInternalHost("192.168.0.1")).isTrue();
+    }
+
+    // ---- isInternalHost: link-local ----
+
+    @Test
+    public void isInternalHost_linkLocal_169_254_returnsTrue() {
+        // AWS / GCP instance metadata endpoint
+        assertThat(SecurityUtils.isInternalHost("169.254.169.254")).isTrue();
+        assertThat(SecurityUtils.isInternalHost("169.254.0.1")).isTrue();
+    }
+
+    // ---- isInternalHost: public IP (not internal) ----
+
+    @Test
+    public void isInternalHost_publicIp_returnsFalse() {
+        assertThat(SecurityUtils.isInternalHost("8.8.8.8")).isFalse();
+        assertThat(SecurityUtils.isInternalHost("1.1.1.1")).isFalse();
+    }
+
+    // ---- isInternalHost: hostname (not an IP literal — never resolved) ----
+
+    @Test
+    public void isInternalHost_publicHostname_returnsFalse() {
+        // Hostnames are never resolved; they are always accepted (not flagged as internal)
+        assertThat(SecurityUtils.isInternalHost("app.customgpt.ai")).isFalse();
+        assertThat(SecurityUtils.isInternalHost("localhost")).isFalse(); // no DNS → not flagged
+    }
+
+    @Test
+    public void isInternalHost_nullOrEmpty_returnsFalse() {
+        assertThat(SecurityUtils.isInternalHost(null)).isFalse();
+        assertThat(SecurityUtils.isInternalHost("")).isFalse();
+        assertThat(SecurityUtils.isInternalHost("   ")).isFalse();
+    }
+
+    // ---- isHttpsUrl: SSRF guard for private IPs ----
+
+    @Test
+    public void isHttpsUrl_loopbackIpLiteral_rejected() {
+        assertThat(SecurityUtils.isHttpsUrl("https://127.0.0.1/api")).isFalse();
+    }
+
+    @Test
+    public void isHttpsUrl_rfc1918_10Block_rejected() {
+        assertThat(SecurityUtils.isHttpsUrl("https://10.0.0.1/api")).isFalse();
+    }
+
+    @Test
+    public void isHttpsUrl_rfc1918_192_168_rejected() {
+        assertThat(SecurityUtils.isHttpsUrl("https://192.168.1.1/api")).isFalse();
+    }
+
+    @Test
+    public void isHttpsUrl_linkLocal_metadataEndpoint_rejected() {
+        assertThat(SecurityUtils.isHttpsUrl("https://169.254.169.254/latest/meta-data/")).isFalse();
+    }
+
+    @Test
+    public void isHttpsUrl_ipv6Loopback_rejected() {
+        // URI with IPv6 literal: https://[::1]/api
+        assertThat(SecurityUtils.isHttpsUrl("https://[::1]/api")).isFalse();
+    }
+
+    @Test
+    public void isHttpsUrl_publicIpLiteral_accepted() {
+        // A public IP literal (not in any private range) should be accepted
+        assertThat(SecurityUtils.isHttpsUrl("https://8.8.8.8/api")).isTrue();
+    }
+
+    @Test
+    public void isHttpsUrl_publicHostname_accepted() {
+        assertThat(SecurityUtils.isHttpsUrl("https://app.customgpt.ai/api/v1/")).isTrue();
+    }
+
+    @Test
+    public void isHttpsUrl_productionDefaultUrl_accepted() {
+        // The literal constant used in CustomGptConstants.DEFAULT_CUSTOM_GPT_API_BASE_URL
+        assertThat(SecurityUtils.isHttpsUrl("https://app.customgpt.ai/api/v1")).isTrue();
+    }
+
+    // ---- dangerous URI schemes ----
+
+    @Test
+    public void isHttpsUrl_javascriptScheme_rejected() {
+        assertThat(SecurityUtils.isHttpsUrl("javascript:alert(1)")).isFalse();
+    }
+
+    @Test
+    public void isHttpsUrl_dataScheme_rejected() {
+        assertThat(SecurityUtils.isHttpsUrl("data:text/html,<h1>hi</h1>")).isFalse();
+    }
+
+    @Test
+    public void isHttpsUrl_ftpScheme_rejected() {
+        assertThat(SecurityUtils.isHttpsUrl("ftp://app.customgpt.ai/file")).isFalse();
+    }
+
+    // ---- isMaskedPlaceholder: substring-not-equals guard ----
+
+    @Test
+    public void isMaskedPlaceholder_valueContainingPlaceholderAsSubstring_isFalse() {
+        // A value that contains "********" as a substring but is not exactly the placeholder
+        // must NOT be treated as the sentinel — the caller must still persist it.
+        final String notExactly = SecurityUtils.SECRET_PLACEHOLDER + "extra";
+        assertThat(SecurityUtils.isMaskedPlaceholder(notExactly)).isFalse();
+    }
+
+    @Test
+    public void isMaskedPlaceholder_placeholderWithLeadingSpace_isFalse() {
+        assertThat(SecurityUtils.isMaskedPlaceholder(" " + SecurityUtils.SECRET_PLACEHOLDER)).isFalse();
+    }
+
+    // ---- resolveHttpsBaseUrl: SSRF guard ----
+
+    @Test
+    public void resolveHttpsBaseUrl_privateIpBaseUrl_throwsIllegalState() {
+        assertThatThrownBy(() ->
+                SecurityUtils.resolveHttpsBaseUrl("https://192.168.1.99/api", "https://app.customgpt.ai/api/v1"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("https");
+    }
+
+    @Test
+    public void resolveHttpsBaseUrl_loopbackIpBaseUrl_throwsIllegalState() {
+        assertThatThrownBy(() ->
+                SecurityUtils.resolveHttpsBaseUrl("https://127.0.0.1/api", "https://app.customgpt.ai/api/v1"))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void resolveHttpsBaseUrl_metadataEndpointBaseUrl_throwsIllegalState() {
+        assertThatThrownBy(() ->
+                SecurityUtils.resolveHttpsBaseUrl("https://169.254.169.254/latest", "https://app.customgpt.ai/api/v1"))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/src/test/java/org/jahia/community/modules/customgpt/util/SecurityUtilsAdditionalTest.java
+++ b/src/test/java/org/jahia/community/modules/customgpt/util/SecurityUtilsAdditionalTest.java
@@ -120,6 +120,40 @@ public class SecurityUtilsAdditionalTest {
         assertThat(SecurityUtils.isHttpsUrl("https://[::1]/api")).isFalse();
     }
 
+    // ---- isHttpsUrl: dotless / decimal IPv4 SSRF bypass (regression) ----
+
+    @Test
+    public void isHttpsUrl_dotlessDecimalLoopback_rejected() {
+        // 2130706433 == 127.0.0.1; Java's resolver collapses it to loopback, so it MUST be rejected
+        // even though the host string contains no dot. Previously treated as a hostname → SSRF bypass.
+        assertThat(SecurityUtils.isHttpsUrl("https://2130706433/api")).isFalse();
+    }
+
+    @Test
+    public void isHttpsUrl_dotlessZeroAnyAddress_rejected() {
+        // 0 == 0.0.0.0 (the wildcard / any-local address); must be rejected as internal.
+        assertThat(SecurityUtils.isHttpsUrl("https://0/api")).isFalse();
+    }
+
+    @Test
+    public void isInternalHost_dotlessDecimalLoopback_returnsTrue() {
+        assertThat(SecurityUtils.isInternalHost("2130706433")).isTrue();
+    }
+
+    @Test
+    public void isInternalHost_dotlessZeroAnyAddress_returnsTrue() {
+        assertThat(SecurityUtils.isInternalHost("0")).isTrue();
+        assertThat(SecurityUtils.isInternalHost("0.0.0.0")).isTrue();
+    }
+
+    @Test
+    public void resolveHttpsBaseUrl_dotlessDecimalLoopback_throwsIllegalState() {
+        assertThatThrownBy(() ->
+                SecurityUtils.resolveHttpsBaseUrl("https://2130706433/api", "https://app.customgpt.ai/api/v1"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("https");
+    }
+
     @Test
     public void isHttpsUrl_publicIpLiteral_accepted() {
         // A public IP literal (not in any private range) should be accepted

--- a/src/test/java/org/jahia/community/modules/customgpt/util/SecurityUtilsAdditionalTest.java
+++ b/src/test/java/org/jahia/community/modules/customgpt/util/SecurityUtilsAdditionalTest.java
@@ -136,6 +136,20 @@ public class SecurityUtilsAdditionalTest {
     }
 
     @Test
+    public void isHttpsUrl_hexLoopback_rejected() {
+        // 0x7f000001 == 127.0.0.1 in hex notation; the 'x' previously made isIpLiteral skip the range
+        // check, treating it as a hostname → SSRF bypass. It must now be classified as an IP literal
+        // and rejected (range-checked, or fail-safe on UnknownHostException).
+        assertThat(SecurityUtils.isHttpsUrl("https://0x7f000001/api")).isFalse();
+        assertThat(SecurityUtils.isHttpsUrl("https://0x7f.0.0.1/api")).isFalse();
+    }
+
+    @Test
+    public void isInternalHost_hexLoopback_returnsTrue() {
+        assertThat(SecurityUtils.isInternalHost("0x7f000001")).isTrue();
+    }
+
+    @Test
     public void isInternalHost_dotlessDecimalLoopback_returnsTrue() {
         assertThat(SecurityUtils.isInternalHost("2130706433")).isTrue();
     }

--- a/tests/cypress/e2e/01-customGptSettings.cy.ts
+++ b/tests/cypress/e2e/01-customGptSettings.cy.ts
@@ -83,8 +83,8 @@ describe('CustomGPT.ai Settings', () => {
                     contentIndexedSubNodeTypes: 'jmix:droppableContent',
                     contentIndexedFileExtensions: 'pdf,docx',
                     operationsBatchSize: 100,
-                    projectId: Cypress.env('CUSTOMGPT_PROJECT_ID'),
-                    token: Cypress.env('CUSTOMGPT_TOKEN'),
+                    projectId: 'roundtrip-project',
+                    token: 'roundtrip-token',
                     jahiaUsername: 'root',
                     jahiaPassword: Cypress.env('SUPER_USER_PASSWORD'),
                     jahiaServerCookieName: 'roundtrip-cookie',
@@ -102,10 +102,10 @@ describe('CustomGPT.ai Settings', () => {
                     expect(s.contentIndexedSubNodeTypes).to.eq('jmix:droppableContent');
                     expect(s.contentIndexedFileExtensions).to.eq('pdf,docx');
                     expect(s.operationsBatchSize).to.eq(100);
-                    expect(s.projectId).to.eq(Cypress.env('CUSTOMGPT_PROJECT_ID'));
+                    expect(s.projectId).to.eq('roundtrip-project');
                     // Secrets are write-only: a stored value is masked, never echoed back in cleartext (SECURITY-746).
                     expect(s.token).to.eq('********');
-                    expect(s.token).to.not.eq(Cypress.env('CUSTOMGPT_TOKEN'));
+                    expect(s.token).to.not.eq('roundtrip-token');
                     expect(s.jahiaUsername).to.eq('root');
                     expect(s.jahiaPassword).to.eq('********');
                     expect(s.jahiaPassword).to.not.eq(Cypress.env('SUPER_USER_PASSWORD'));

--- a/tests/cypress/e2e/02-indexing.cy.ts
+++ b/tests/cypress/e2e/02-indexing.cy.ts
@@ -151,10 +151,12 @@ describe('CustomGPT.ai Indexing', function () {
     });
 
     after(() => {
-        // cy.apollo({
-        //     mutation: saveSettings,
-        //     variables: {dryRun: true, scheduleJobASAP: false}
-        // });
+        // Always reset the dry-run / scheduling state, even when a test above fails —
+        // Cypress runs `after` hooks unconditionally, so this keeps the module config clean.
+        cy.apollo({
+            mutation: saveSettings,
+            variables: {dryRun: true, scheduleJobASAP: false}
+        });
     });
 
     // ─── Site indexing ───────────────────────────────────────────────────────────

--- a/tests/cypress/e2e/03-new-page.cy.ts
+++ b/tests/cypress/e2e/03-new-page.cy.ts
@@ -84,11 +84,13 @@ describe('CustomGPT.ai new page indexing', function () {
                 variables: {nodePaths: [testPagePath()]}
             });
 
-            cy.wait(10000)
-
-            cy.apollo({query: getNodeStatus, variables: {path: `${testPagePath()}/customgptIndex`}}).then(result => {
-                return Boolean(result.data.jcr.nodeByPath?.property?.value);
-            });
+            cy.waitUntil(
+                () =>
+                    cy
+                        .apollo({query: getNodeStatus, variables: {path: `${testPagePath()}/customgptIndex`}})
+                        .then(result => Boolean(result.data.jcr.nodeByPath?.property?.value)),
+                {timeout: 60000, interval: 1000, errorMsg: 'Timed out waiting for customGptPageId to be set on the new page'}
+            );
 
             cy.apollo({query: getNodeStatus, variables: {path: `${testPagePath()}/customgptIndex`}})
                 .its('data.jcr.nodeByPath')

--- a/tests/cypress/e2e/04-customGpt-Permissions.cy.ts
+++ b/tests/cypress/e2e/04-customGpt-Permissions.cy.ts
@@ -35,6 +35,10 @@ describe('CustomGPT.ai — permission enforcement', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const getSettings: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/query/getSettings.graphql');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const saveSettings: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/mutation/saveSettings.graphql');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const purgeAllPages: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/mutation/purgeAllPages.graphql');
 
     const errorsOf = (result: {graphQLErrors?: Array<{message: string}>; errors?: Array<{message: string}>}) =>
         result.graphQLErrors ?? result.errors ?? [];
@@ -42,6 +46,16 @@ describe('CustomGPT.ai — permission enforcement', () => {
     const querySettingsAs = (username: string) => {
         cy.apolloClient({username, password: PASSWORD});
         return cy.apollo({query: getSettings});
+    };
+
+    const saveSettingsAs = (username: string) => {
+        cy.apolloClient({username, password: PASSWORD});
+        return cy.apollo({mutation: saveSettings, variables: {dryRun: true, scheduleJobASAP: false}});
+    };
+
+    const purgeAllPagesAs = (username: string) => {
+        cy.apolloClient({username, password: PASSWORD});
+        return cy.apollo({mutation: purgeAllPages});
     };
 
     before(() => {
@@ -63,6 +77,22 @@ describe('CustomGPT.ai — permission enforcement', () => {
     describe('GraphQL API authorization', () => {
         it('denies the gated query for a user without the permission', () => {
             querySettingsAs(DENIED_USER).then((result: never) => {
+                const errs = errorsOf(result);
+                expect(errs, 'denial errors').to.have.length.greaterThan(0);
+                expect(errs.map((e: {message: string}) => e.message).join(' ')).to.contain('Permission denied');
+            });
+        });
+
+        it('denies the state-changing saveSettings mutation for a user without the permission', () => {
+            saveSettingsAs(DENIED_USER).then((result: never) => {
+                const errs = errorsOf(result);
+                expect(errs, 'denial errors').to.have.length.greaterThan(0);
+                expect(errs.map((e: {message: string}) => e.message).join(' ')).to.contain('Permission denied');
+            });
+        });
+
+        it('denies the destructive purgeAllPages mutation for a user without the permission', () => {
+            purgeAllPagesAs(DENIED_USER).then((result: never) => {
                 const errs = errorsOf(result);
                 expect(errs, 'denial errors').to.have.length.greaterThan(0);
                 expect(errs.map((e: {message: string}) => e.message).join(' ')).to.contain('Permission denied');

--- a/tests/cypress/fixtures/graphql/mutation/purgeAllPages.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/purgeAllPages.graphql
@@ -1,0 +1,7 @@
+mutation purgeAllPages {
+    admin {
+        customGpt {
+            purgeAllPages
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Autonomous **blind multi-level review** (architecture · security · code quality [SonarQube + ESLint] · ergonomy · accessibility AAA · test coverage · documentation) of the `customgpt-ai` module, followed by full remediation. Specialized agents handled each work area; every change was verified end-to-end.

## Security
- **SSRF guard** — reject private/loopback/link-local/unique-local **IP literals** for the CustomGPT API base URL *and* the page-render host (no DNS resolution of arbitrary hostnames). Base-URL `https` is now validated in `Config` so a bad `.cfg` value can't reach the HTTP layer carrying the Bearer token.
- **HTTP timeouts** — explicit connect/read/write/call timeouts on both OkHttp clients (was: infinite read → indexer thread-pool DoS).
- **GraphQL** — resolvers no longer leak internal exception detail (server-side log + generic client message); **audit logging** of admin actions (`saveSettings`/`startIndex`/`startNodeIndex`/`addSite`/`purgeAllPages`) with the sanitized acting user; `addSite` `siteKey` validated against `^[\w-]+$`.

## Correctness / quality (Java)
- Fix `CustomGptIndexOperation` **`equals`/`hashCode` field-set mismatch** that broke `LinkedHashSet` de-duplication.
- Thread-safety: `volatile` + `synchronized` executor restart, `synchronized init()`; narrow broad `catch(Exception)`; fix JCR event-type bit test (`(type & PROPERTY_EVENTS) != 0`); remove dead code (duplicate ACE branch, write-only `nodeToReindex`/`retryOnConflict`, vacuous null guards); `hasProperty` guard; SAM→lambda; rename misspelled constants.

## Frontend / ergonomy
- Remove `console` logging; one-time form init (drop the Apollo `onCompleted` reset that clobbered edits); `NaN` guard + `min`/`max` on numeric inputs; client-side required-field validation; named GraphQL query / route / init functions.

## Accessibility (WCAG 2.2 AAA)
- Native `<output>` polite live regions (deduped); dialog focus return to trigger; `aria-describedby` hints; `aria-invalid` + inline errors; 24px touch targets; AAA-level contrast; `<form>` semantics; `prefers-reduced-motion`; i18n parity (`de`/`fr`).

## Tests
- **Java: 22 → 117 unit tests** (RateLimitInterceptor backoff/429 retry, Indexer dedup, Config parse, Service path predicate, SSRF guard) + **16 Jest/RTL tests** (form helpers + component a11y).
- **Cypress**: masking round-trip test made self-contained (no external-secret dependency); `cy.wait(10000)` → polling; restored teardown; added `saveSettings` + `purgeAllPages` permission-deny tests.

## Build / docs
- Sync `package.json` version to pom (`1.0.7-SNAPSHOT`); add SonarQube properties; correct `AGENTS.md` (React 18, pure OSGi DS).

## Verification
- `mvn clean install` ✅ (JDK 17, **117** Java tests)
- **SonarQube quality gate: OK** — 0 new issues, ratings A, 0% duplication
- ESLint 0 errors · Jest **16/16**
- **Cypress E2E: ✔ all specs passed** — 29 passing / 0 failing / 4 skipped (indexing specs require live CustomGPT credentials)

## Scoped Sonar exclusions (documented)
- `src/javascript/index.js` — 4-line module-federation bootstrap; webpack targets (chrome 60/safari 12) predate `globalThis` & top-level await, so `window` + promise chain are correct.
- `src/main/resources/resources/**` — i18n `.properties` label bundles (S2068 false positive on a "Passwort" *label* translation).